### PR TITLE
API error details

### DIFF
--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -50,7 +50,7 @@ func PostObj(ent int, entity string, data map[string]interface{}) (map[string]in
 
 		return respMap["data"].(map[string]interface{}), nil
 	}
-	return nil, fmt.Errorf(APIErrorPrefix + respMap["message"].(string))
+	return nil, APIError(respMap)
 }
 
 // Calls API's Validation
@@ -75,7 +75,7 @@ func ValidateObj(data map[string]interface{}, ent string, silence bool) bool {
 
 		return true
 	}
-	println("Error: ", string(APIErrorPrefix+respMap["message"].(string)))
+	println("Error: ", APIErrorMsg(respMap))
 	println()
 	return false
 }
@@ -663,15 +663,10 @@ func UpdateObj(Path, id, ent string, data map[string]interface{}, deleteAndPut b
 				}
 
 			} else {
-				if mInf, ok := respJson["message"]; ok {
-					if m, ok := mInf.(string); ok {
-						return nil, fmt.Errorf(APIErrorPrefix + m)
-					}
-				}
 				msg := "Cannot update. Please ensure that your attributes " +
 					"are modifiable and try again. For more details see the " +
-					"OGREE wiki: https://github.com/ditrit/OGrEE-3D/wiki"
-				return nil, fmt.Errorf(msg)
+					"OGREE wiki: https://github.com/ditrit/OGrEE-3D/wiki\n"
+				return nil, fmt.Errorf(msg + APIErrorMsg(respJson))
 			}
 
 		}
@@ -2812,12 +2807,7 @@ func LoadTemplate(data map[string]interface{}, filePath string) error {
 		l.GetWarningLogger().Println("Couldn't load template, Status Code :", r.StatusCode, " filePath :", filePath)
 		parsedResp := ParseResponse(r, e, "sending template")
 		errorMsg := "Error template wasn't loaded\n"
-		if mInf, ok := parsedResp["message"]; ok {
-			if msg, ok := mInf.(string); ok {
-				errorMsg += APIErrorPrefix + msg
-			}
-		}
-		return fmt.Errorf(errorMsg)
+		return fmt.Errorf(errorMsg + APIErrorMsg(parsedResp))
 	}
 }
 

--- a/CLI/controllers/controllerUtils.go
+++ b/CLI/controllers/controllerUtils.go
@@ -40,8 +40,32 @@ const (
 // Error Message Const
 // TODO: Replace Const with Err Msg/Reporting Func
 // that distinguishes API & CLI Errors
-const APIErrorPrefix = "[Response From API] "
 const RACKUNIT = .04445 //meter
+
+func APIErrorMsg(respMap map[string]any) string {
+	respMsgAny, ok := respMap["message"]
+	if !ok {
+		return ""
+	}
+	respMsg, ok := respMsgAny.(string)
+	if !ok {
+		return ""
+	}
+	msg := "[Response From API] " + respMsg
+	errorsAny, ok := respMap["errors"]
+	if !ok {
+		return msg
+	}
+	errorsList := errorsAny.([]any)
+	for _, err := range errorsList {
+		msg += "\n    " + err.(string)
+	}
+	return msg
+}
+
+func APIError(respMap map[string]any) error {
+	return fmt.Errorf(APIErrorMsg(respMap))
+}
 
 // Display contents of []map[string]inf array
 func DispMapArr(x []map[string]interface{}) {


### PR DESCRIPTION
Closes issue 165 from previous repo : [https://github.com/ditrit/OGrEE-CLI/issues/165](url)
The JSON received from the API can have the following format :
```
{
    "errors": [
        "/attributes/usableColor does not match pattern '^[0-9a-fA-F]{6}$'",
        "missing properties: 'name'",
        "additionalProperties 'banana' not allowed"
    ],
    "message": "JSON body doesn't validate with the expected JSON schema",
    "status": false
}
```
The "errors" field is currently ignored, this PR fixes it.