### PR TITLE
Hardcoded and config paths are now relative to the executable file

### DIFF
--- a/CLI/config/config.go
+++ b/CLI/config/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"cli/utils"
+
 	"github.com/BurntSushi/toml"
 	flag "github.com/spf13/pflag"
 )
@@ -53,7 +55,7 @@ func defaultConfig() Config {
 		APIURL:       "",
 		UnityURL:     "",
 		UnityTimeout: "10ms",
-		ConfigPath:   "../config.toml",
+		ConfigPath:   utils.ExeDir() + "/../config.toml",
 		HistPath:     "./.history",
 		Script:       "",
 		Drawable:     []string{"all"},

--- a/CLI/config/config.go
+++ b/CLI/config/config.go
@@ -106,6 +106,6 @@ func ReadConfig() *Config {
 	json.Unmarshal(argBytes, &conf)
 
 	conf.ConfigPath, _ = filepath.Abs(conf.ConfigPath)
-
+	conf.HistPath, _ = filepath.Abs(conf.HistPath)
 	return conf
 }

--- a/CLI/config/config.go
+++ b/CLI/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"cli/utils"
 
@@ -103,6 +104,8 @@ func ReadConfig() *Config {
 
 	argBytes, _ := json.Marshal(args)
 	json.Unmarshal(argBytes, &conf)
+
+	conf.ConfigPath, _ = filepath.Abs(conf.ConfigPath)
 
 	return conf
 }

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -4,6 +4,7 @@ import (
 	"cli/logger"
 	l "cli/logger"
 	"cli/models"
+	"cli/utils"
 	u "cli/utils"
 	"encoding/hex"
 	"encoding/json"
@@ -1198,8 +1199,7 @@ func Help(entry string) {
 	default:
 		path = "./other/man/default.md"
 	}
-
-	text, e := os.ReadFile(path)
+	text, e := os.ReadFile(utils.ExeDir() + "/" + path)
 	if e != nil {
 		println("Manual Page not found!")
 	} else {

--- a/CLI/controllers/initController.go
+++ b/CLI/controllers/initController.go
@@ -7,10 +7,12 @@ import (
 	l "cli/logger"
 	"cli/models"
 	"cli/readline"
+	"cli/utils"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -309,6 +311,9 @@ func SetDrawableTemplate(entity string, DrawableJson map[string]string) map[stri
 		objStr = strings.Trim(objStr, "'\"")
 		//Now retrieve file
 		ans := map[string]interface{}{}
+		if !filepath.IsAbs(objStr) {
+			objStr = utils.ExeDir() + "/" + objStr
+		}
 		f, e := os.ReadFile(objStr)
 		if e == nil {
 			json.Unmarshal(f, &ans)

--- a/CLI/logger/logger.go
+++ b/CLI/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"cli/utils"
 	"log"
 	"os"
 )
@@ -15,12 +16,12 @@ var (
 )
 
 func InitLogs() {
-	file, err := os.OpenFile("log.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	file, err := os.OpenFile(utils.ExeDir()+"/log.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	f2, err2 := os.OpenFile("unitylog.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	f2, err2 := os.OpenFile(utils.ExeDir()+"unitylog.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err2 != nil {
 		log.Fatal(err2)
 	}

--- a/CLI/utils/util.go
+++ b/CLI/utils/util.go
@@ -9,7 +9,17 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 )
+
+func ExeDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Dir(exe)
+}
 
 func Message(status bool, message string) map[string]interface{} {
 	return map[string]interface{}{"status": status, "message": message}


### PR DESCRIPTION
Currently, if the CLI executable is not run from the CLI directory, it will not use the correct paths for the manual pages, the text logs, config.toml etc... This PR fixes it.