### PR TITLE
CLI asks for login instead of creating an account

### DIFF
--- a/API/controllers/authControllers.go
+++ b/API/controllers/authControllers.go
@@ -62,7 +62,7 @@ var CreateAccount = func(w http.ResponseWriter, r *http.Request) {
 			u.Respond(w, u.Message(false, "Invalid request"))
 			return
 		}
-		resp, e := account.Create()
+		resp, e := account.Create(false)
 		switch e {
 		case "internal":
 			w.WriteHeader(http.StatusInternalServerError)
@@ -131,16 +131,8 @@ var Authenticate = func(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		resp, e := models.Login(account.Email, account.Password)
-		if resp["status"] == false {
-			if e == "invalid" {
-				w.WriteHeader(http.StatusUnauthorized)
-			} else if e == "internal" {
-				w.WriteHeader(http.StatusInternalServerError)
-			} else if e == "clientError" {
-				w.WriteHeader(http.StatusBadRequest)
-			}
-		}
+		resp, statusCode := models.Login(account.Email, account.Password)
+		w.WriteHeader(statusCode)
 		u.Respond(w, resp)
 	}
 }

--- a/API/controllers/authControllers.go
+++ b/API/controllers/authControllers.go
@@ -62,7 +62,7 @@ var CreateAccount = func(w http.ResponseWriter, r *http.Request) {
 			u.Respond(w, u.Message(false, "Invalid request"))
 			return
 		}
-		resp, e := account.Create(false)
+		resp, e := account.Create()
 		switch e {
 		case "internal":
 			w.WriteHeader(http.StatusInternalServerError)

--- a/API/main.go
+++ b/API/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"p3/app"
 	"p3/controllers"
-	"p3/models"
 
 	"net/http"
 	"os"
@@ -157,9 +156,6 @@ func Router(jwt func(next http.Handler) http.Handler) *mux.Router {
 }
 
 func main() {
-	account := models.Account{Email: "admin", Password: "admin"}
-	account.Create(true)
-
 	//TODO:
 	//Use the URL below to help make the router functions more
 	//flexible and thus implement the http OPTIONS method

--- a/API/main.go
+++ b/API/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"p3/app"
 	"p3/controllers"
+	"p3/models"
 
 	"net/http"
 	"os"
@@ -156,6 +157,9 @@ func Router(jwt func(next http.Handler) http.Handler) *mux.Router {
 }
 
 func main() {
+	account := models.Account{Email: "admin", Password: "admin"}
+	account.Create(true)
+
 	//TODO:
 	//Use the URL below to help make the router functions more
 	//flexible and thus implement the http OPTIONS method

--- a/API/models/accounts.go
+++ b/API/models/accounts.go
@@ -54,12 +54,9 @@ func (account *Account) Validate() (map[string]interface{}, bool) {
 	return u.Message(false, "Requirement passed"), true
 }
 
-func (account *Account) Create(skipValidation bool) (map[string]interface{}, string) {
-
-	if !skipValidation {
-		if resp, ok := account.Validate(); !ok {
-			return resp, "exists"
-		}
+func (account *Account) Create() (map[string]interface{}, string) {
+	if resp, ok := account.Validate(); !ok {
+		return resp, "exists"
 	}
 
 	hashedPassword, _ := bcrypt.GenerateFromPassword(

--- a/CLI/config/config.go
+++ b/CLI/config/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	DrawLimit    int
 	Updates      []string
 	User         string
-	APIKEY       string
 	Variables    []Vardef
 }
 
@@ -45,7 +44,6 @@ type ArgStruct struct {
 	Verbose    string `json:",omitempty"`
 	UnityURL   string `json:",omitempty"`
 	APIURL     string `json:",omitempty"`
-	APIKEY     string `json:",omitempty"`
 	HistPath   string `json:",omitempty"`
 	Script     string `json:",omitempty"`
 }
@@ -64,7 +62,6 @@ func defaultConfig() Config {
 		DrawLimit:    50,
 		Updates:      []string{"all"},
 		User:         "",
-		APIKEY:       "",
 		Variables:    []Vardef{},
 	}
 }
@@ -84,7 +81,6 @@ func ReadConfig() *Config {
 			"{NONE,ERROR,WARNING,INFO,DEBUG}.")
 	flag.StringVarP(&args.UnityURL, "unity_url", "u", conf.UnityURL, "Unity URL")
 	flag.StringVarP(&args.APIURL, "api_url", "a", conf.APIURL, "API URL")
-	flag.StringVarP(&args.APIKEY, "api_key", "k", conf.APIKEY, "Indicate the key of the API")
 	flag.StringVarP(&args.HistPath, "history_path", "h", conf.HistPath,
 		"Indicate the location of the Shell's history file")
 	flag.StringVarP(&args.Script, "file", "f", conf.Script, "Launch the shell as an interpreter "+

--- a/CLI/controllers/initController.go
+++ b/CLI/controllers/initController.go
@@ -10,11 +10,10 @@ import (
 	"cli/utils"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -350,92 +349,45 @@ func SetDrawableTemplate(entity string, DrawableJson map[string]string) map[stri
 	return nil
 }
 
-func CreateCredentials() (string, string) {
-	var tp map[string]interface{}
-
-	user, _ := readline.Line("Please Enter desired user email: ")
-	pass, _ := readline.Password("Please Enter desired password: ")
-	data := map[string]interface{}{"email": user, "password": string(pass)}
-
-	resp, e := models.Send("POST", State.APIURL+"/api", "", data)
-	tp = ParseResponse(resp, e, "Create credentials")
-	if tp == nil {
-		println(e.Error())
-		os.Exit(-1)
-	}
-
-	if tp["status"] != nil {
-		if !tp["status"].(bool) {
-			errMessage := "Error while creating credentials : " + tp["message"].(string)
-			if State.DebugLvl > 0 {
-				println(errMessage)
-			}
-			l.GetErrorLogger().Println(errMessage)
-			os.Exit(-1)
+func Login(user string) (string, string, error) {
+	var err error
+	if user == "" {
+		user, err = readline.Line("User: ")
+		if err != nil {
+			return "", "", fmt.Errorf("readline error : %s", err.Error())
 		}
-	} else {
-		if State.DebugLvl > 0 {
-			println("An error occurred while creating credentials")
-			l.GetErrorLogger().Println("Could not read API status on create credential attempt")
-		}
-		os.Exit(-1)
 	}
-
-	token := (tp["account"].(map[string]interface{}))["token"].(string)
-	l.GetInfoLogger().Println("Credentials created")
-	return user, token
-}
-
-func CheckEmailIsValid(email string) bool {
-	emailRegex := "(\\w)+@(\\w)+\\.(\\w)+"
-	return regexp.MustCompile(emailRegex).MatchString(email)
-}
-
-func CheckKeyIsValid(key string) bool {
-	resp, err := models.Send("GET", State.APIURL+"/api/token/valid", key, nil)
+	pass, err := readline.Password("Password: ")
 	if err != nil {
-		if State.DebugLvl > 0 {
-			l.GetErrorLogger().Println("Unable to connect to API: ", State.APIURL)
-			l.GetErrorLogger().Println(err.Error())
-			println(err.Error())
-		}
-		return false
+		return "", "", err
 	}
-	if resp.StatusCode != 200 {
-		println("HTTP Response Status code : " + strconv.Itoa(resp.StatusCode))
-		if State.DebugLvl > NONE {
-			x := ParseResponse(resp, err, " Read API Response message")
-			if x != nil {
-				if x["message"] != nil && x["message"] != "" {
-					println("[API] " + x["message"].(string))
-				} else {
-					println("Was not able to read API Response message")
-				}
-			} else {
-				println("Was not able to read API Response message")
-			}
-		}
-		return false
+	data := map[string]any{"email": user, "password": string(pass)}
+	rawResp, err := models.Send("POST", State.APIURL+"/api/login", "", data)
+	if err != nil {
+		return "", "", fmt.Errorf("error sending login request : %s", err.Error())
 	}
-	return true
-}
-
-func Login(user string, key string) (string, string) {
-	if key == "" || !CheckEmailIsValid(user) || !CheckKeyIsValid(key) {
-		l.GetInfoLogger().Println("Credentials not found or invalid, going to generate..")
-		if State.DebugLvl > NONE {
-			println("Credentials not found or invalid, going to generate..")
-		}
-		user, key = CreateCredentials()
-		fmt.Printf("Here is your api key, you can save it to your config.toml file :\n%s\n", key)
+	bodyBytes, err := io.ReadAll(rawResp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("error reading answer from API : %s", err.Error())
 	}
-	if !CheckKeyIsValid(key) {
-		if State.DebugLvl > 0 {
-			println("Error while checking key. Now exiting")
-		}
-		l.GetErrorLogger().Println("Error while checking key. Now exiting")
-		os.Exit(-1)
+	var resp map[string]any
+	if err = json.Unmarshal(bodyBytes, &resp); err != nil {
+		return "", "", fmt.Errorf("error parsing response : %s", err.Error())
 	}
-	l.GetInfoLogger().Println("Successfully Logged In")
-	return user, key
+	status, ok := resp["status"].(bool)
+	if !ok {
+		return "", "", fmt.Errorf("invalid response from API")
+	}
+	if !status {
+		return "", "", fmt.Errorf(resp["message"].(string))
+	}
+	account, ok := (resp["account"].(map[string]interface{}))
+	if !ok {
+		return "", "", fmt.Errorf("invalid response from API")
+	}
+	token, ok := account["token"].(string)
+	if !ok {
+		return "", "", fmt.Errorf("invalid response from API")
+	}
+	return user, token, nil
 }

--- a/CLI/main.go
+++ b/CLI/main.go
@@ -22,15 +22,24 @@ func main() {
 	l.InitLogs()
 	c.InitConfigFilePath(conf.ConfigPath)
 	c.InitHistoryFilePath(conf.HistPath)
-	c.InitDebugLevel(conf.Verbose)         //Set the Debug level
-	c.InitTimeout(conf.UnityTimeout)       //Set the Unity Timeout
-	c.InitURLs(conf.APIURL, conf.UnityURL) //Set the URLs
+	c.InitDebugLevel(conf.Verbose)
+	c.InitTimeout(conf.UnityTimeout)
+	c.InitURLs(conf.APIURL, conf.UnityURL)
 
-	conf.User, conf.APIKEY = c.Login(conf.User, conf.APIKEY)
-	c.InitEmail(conf.User) //Set the User email
-	c.InitKey(conf.APIKEY) //Set the API Key
+	var err error
+	var apiKey string
+	conf.User, apiKey, err = c.Login(conf.User)
+	if err != nil {
+		println(err.Error())
+		return
+	} else {
+		println("Successfully connected")
+	}
+
+	c.InitEmail(conf.User)
+	c.InitKey(apiKey)
 	c.InitState(conf)
-	err := InitVars(conf.Variables)
+	err = InitVars(conf.Variables)
 	if err != nil {
 		println("Error while initializing variables :", err.Error())
 		return


### PR DESCRIPTION
We now ask a login/password everytime the user starts the CLI.
The apiKey is removed from the config.toml.
A default admin account (with password "admin") is created by the API when it starts.
I did that in the main.go file rather than the createdb.js so that I can use the normal creation route which is using the bcrypt package to hash the password. 