### PR TITLE
fixes incomplete type switch for posU/slot

### DIFF
--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -1661,19 +1661,24 @@ func GetOCLIAtrributes(Path string, ent int, data map[string]interface{}) error 
 		if x, ok := attr["posU/slot"]; ok {
 			delete(attr, "posU/slot")
 			//Convert posU to string if numeric
-			if _, ok := x.(float64); ok {
-				x = strconv.FormatFloat(x.(float64), 'G', -1, 64)
+			switch xval := x.(type) {
+			case float64:
+				xstr := strconv.FormatFloat(xval, 'G', -1, 64)
 				attr["posU"] = x
 				attr["slot"] = ""
-				slot, err = GetSlot(parent, x.(string))
-			} else if _, ok := x.(int); ok {
-				x = strconv.Itoa(x.(int))
+				slot, err = GetSlot(parent, xstr)
+				x = xstr
+			case int:
+				xstr := strconv.Itoa(xval)
 				attr["posU"] = x
 				attr["slot"] = ""
-				slot, err = GetSlot(parent, x.(string))
-			} else {
-				attr["slot"] = x
-				slot, err = GetSlot(parent, x.(string))
+				slot, err = GetSlot(parent, xstr)
+				x = xstr
+			case string:
+				attr["slot"] = xval
+				slot, err = GetSlot(parent, xval)
+			default:
+				return fmt.Errorf("posU/slot should be a string or a number")
 			}
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes that bug :
```
herve@exaion:/Physical/MGF/RDC/R3> +dv:/P/MGF/RDC/R3/CLIM4    @[1.65,11-.85] @ 0 @[1.75, 0.85]
panic: interface conversion: interface {} is []float64, not string

goroutine 1 [running]:
cli/controllers.GetOCLIAtrributes({0xc00021c8e0, 0x1a}, 0x4, 0xa?)
        /OGrEE/OGrEE-Core/CLI/controllers/commandController.go:1676 +0x3465
main.(*createDeviceNode).execute(0xc00050e5c0)
        /OGrEE/OGrEE-Core/CLI/ast.go:1228 +0x27e
main.InterpretLine({0xc000240a00?, 0xc000240080?})
        /OGrEE/OGrEE-Core/CLI/repl.go:28 +0x52
main.Start(0xc0002120a8, {0xc0000ac648, 0x5})
        /OGrEE/OGrEE-Core/CLI/repl.go:48 +0x85
main.main()
        /OGrEE/OGrEE-Core/CLI/main.go:68 +0x79f
```

