### PR TITLE
refactor(app): naming and restart superadmin + .env usage

### DIFF
--- a/APP/launch.ps1
+++ b/APP/launch.ps1
@@ -7,7 +7,7 @@ docker build . -t ogree-app
 $assetsDir = "${PWD}\ogree_app\assets\custom"
 $file = "${assetsDir}\.env"
 (Get-Content $file) -replace '8081', $portBack | Set-Content $file
-docker run -p ${portWeb}:80 -v ${assetsDir}:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
+docker run --restart always --name ogree-superadmin -p ${portWeb}:80 -v ${assetsDir}:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
 
 cd .\ogree_app_backend
 docker run --rm -v ${PWD}:/workdir -w /workdir -e GOOS=windows golang go build -o ogree_app_backend.exe

--- a/APP/launch.sh
+++ b/APP/launch.sh
@@ -15,7 +15,7 @@ assetsDir="$(pwd)/ogree_app/assets/custom"
 file="$assetsDir/.env"
 docker build . -t ogree-app
 sed -i "s/8081/$portBack/g" $file
-docker run -p $portWeb:80 -v $assetsDir:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
+docker run --restart always --name ogree-superadmin -p $portWeb:80 -v $assetsDir:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
 
 cd ./ogree_app_backend
 docker run --rm -v $(pwd):/workdir -w /workdir golang go build -o ogree_app_backend

--- a/APP/ogree_app_backend/tenant.go
+++ b/APP/ogree_app_backend/tenant.go
@@ -203,22 +203,18 @@ func dockerCreateTenant(newTenant tenant) string {
 		args = append(args, "--profile")
 		args = append(args, "doc")
 	}
+	args = append(args, "--env-file")
+	envFilename := DOCKER_DIR + tenantLower + ".env"
+	args = append(args, envFilename)
 	args = append(args, "up")
 	args = append(args, "--build")
 	args = append(args, "-d")
 
-	// Create .env file
-	file, _ := os.Create(DOCKER_DIR + ".env")
+	// Create tenantName.env
+	file, _ := os.Create(envFilename)
 	err := tmplt.Execute(file, newTenant)
 	if err != nil {
-		panic(err)
-	}
-	file.Close()
-	// Create tenantName.env as a copy
-	file, _ = os.Create(DOCKER_DIR + tenantLower + ".env")
-	err = tmplt.Execute(file, newTenant)
-	if err != nil {
-		fmt.Println("Error creating .env copy: " + err.Error())
+		panic("Error creating .env: " + err.Error())
 	}
 	file.Close()
 


### PR DESCRIPTION
## Description

Improve docker command to include naming and restarting with launch scripts as well as docker compose usage of custom tenant.env file only (stop using default .env).

Fixes #162 

## Type of change

Refactor/Chore.

# How Has This Been Tested?

Local test on Windows.