### PR TITLE
Wildcards

### DIFF
--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -382,6 +382,38 @@ func HandleGenericObject(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// swagger:operation GET /api/objects/{id-wildcard} Objects GetGenericObjectWildcard
+// Get the list of objects whose id matches {id-wildcard}.
+// ---
+// security:
+// - bearer: []
+// produces:
+// - application/json
+// parameters:
+//   - name: id
+//     in: path
+//     description: id (that can contains wildcards) of the objects to retrieve
+//     required: true
+//   - name: fieldOnly
+//     in: query
+//     description: 'specify which object field to show in response.
+//     Multiple fieldOnly can be added. An invalid field is simply ignored.'
+//   - name: startDate
+//     in: query
+//     description: 'filter objects by lastUpdated >= startDate.
+//     Format: yyyy-mm-dd'
+//   - name: endDate
+//     in: query
+//     description: 'filter objects by lastUpdated <= endDate.
+//     Format: yyyy-mm-dd'
+//
+// responses:
+//
+//		'200':
+//		    description: 'Found. A response body will be returned with
+//	        a meaningful message.'
+//		'404':
+//		    description: Not Found. An error message will be returned.
 func HandleGenericObjectWildcard(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("******************************************************")
 	fmt.Println("FUNCTION CALL: 	 GetGenericObjectWildcard ")

--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -382,6 +382,54 @@ func HandleGenericObject(w http.ResponseWriter, r *http.Request) {
 
 }
 
+func HandleGenericObjectWildcard(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("******************************************************")
+	fmt.Println("FUNCTION CALL: 	 GetGenericObjectWildcard ")
+	fmt.Println("******************************************************")
+	DispRequestMetaData(r)
+	user := getUserFromToken(w, r)
+	if user == nil {
+		return
+	}
+	hierarchyName, ok := mux.Vars(r)["id"]
+	if !ok {
+		u.Respond(w, u.Message("Error while parsing path"))
+		u.ErrLog("Error while parsing path", "GetGenericObjectWildcard", "", r)
+		return
+	}
+	filters := getFiltersFromQueryParams(r)
+	regex := strings.ReplaceAll(strings.ReplaceAll(hierarchyName, ".", "\\."), "*", "(\\w(\\w|\\-)*)")
+	req := bson.M{"id": bson.M{"$regex": regex}}
+	matchingObjects := []map[string]interface{}{}
+	rangeEntities := u.HierachyNameToEntity(hierarchyName)
+	for _, entity := range rangeEntities {
+		entityStr := u.EntityToString(entity)
+		data, err := models.GetManyEntities(entityStr, req, filters, user.Roles)
+		if err != nil {
+			u.ErrLog("Error while looking for matching "+entityStr+"s", "GetGenericObjectWildcard", err.Message, r)
+			u.RespondWithError(w, err)
+			return
+		}
+		if data != nil {
+			matchingObjects = append(matchingObjects, data...)
+		}
+	}
+	if r.Method == "DELETE" {
+		for _, obj := range matchingObjects {
+			modelErr := models.DeleteEntity(obj["category"].(string), obj["id"].(string), user.Roles)
+			if modelErr != nil {
+				u.ErrLog("Error while deleting entity", "DELETE ENTITY", modelErr.Message, r)
+				u.RespondWithError(w, modelErr)
+			} else {
+				w.WriteHeader(http.StatusNoContent)
+				u.Respond(w, u.Message("successfully deleted"))
+			}
+		}
+	} else {
+		u.Respond(w, u.RespDataWrapper("successfully got objects", matchingObjects))
+	}
+}
+
 // swagger:operation GET /api/{entity}/{id} Objects GetEntity
 // Gets an Object of the given entity.
 // The ID or hierarchy name must be provided in the URL parameter.

--- a/API/main.go
+++ b/API/main.go
@@ -98,6 +98,9 @@ func Router(jwt func(next http.Handler) http.Handler) *mux.Router {
 	router.HandleFunc("/api/objects/{id}",
 		controllers.HandleGenericObject).Methods("GET", "HEAD", "OPTIONS", "DELETE")
 
+	router.HandleFunc("/api/objects-wildcard/{id}",
+		controllers.HandleGenericObjectWildcard).Methods("GET", "HEAD", "OPTIONS", "DELETE")
+
 	//GET ENTITY HIERARCHY
 	router.NewRoute().PathPrefix("/api/{entity}s/{id}/all").
 		MatcherFunc(hnmatch).HandlerFunc(controllers.GetHierarchyByName).Methods("GET", "HEAD", "OPTIONS")

--- a/API/swagger.json
+++ b/API/swagger.json
@@ -170,6 +170,54 @@
         }
       }
     },
+    "/api/objects/{id-wildcard}": {
+      "get": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Objects"
+        ],
+        "summary": "Get the list of objects whose id matches {id-wildcard}.",
+        "operationId": "GetGenericObjectWildcard",
+        "parameters": [
+          {
+            "description": "id (that can contains wildcards) of the objects to retrieve",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "specify which object field to show in response. Multiple fieldOnly can be added. An invalid field is simply ignored.",
+            "name": "fieldOnly",
+            "in": "query"
+          },
+          {
+            "description": "filter objects by lastUpdated \u003e= startDate. Format: yyyy-mm-dd",
+            "name": "startDate",
+            "in": "query"
+          },
+          {
+            "description": "filter objects by lastUpdated \u003c= endDate. Format: yyyy-mm-dd",
+            "name": "endDate",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found. A response body will be returned with a meaningful message."
+          },
+          "404": {
+            "description": "Not Found. An error message will be returned."
+          }
+        }
+      }
+    },
     "/api/objects/{id}": {
       "get": {
         "security": [

--- a/API/utils/util.go
+++ b/API/utils/util.go
@@ -95,7 +95,7 @@ func Message(message string) map[string]interface{} {
 	return map[string]interface{}{"message": message}
 }
 
-func RespDataWrapper(message string, data map[string]interface{}) map[string]interface{} {
+func RespDataWrapper(message string, data interface{}) map[string]interface{} {
 	return map[string]interface{}{"message": message, "data": data}
 }
 

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -290,6 +290,9 @@ func (n *deleteObjNode) execute() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	if strings.Contains(path, "*") {
+		return nil, cmd.DeleteObjectsWildcard(path)
+	}
 	return nil, cmd.DeleteObj(path)
 }
 

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -658,6 +658,11 @@ func (n *updateObjNode) execute() (interface{}, error) {
 	var paths []string
 	if path == "_" {
 		paths = cmd.State.ClipBoard
+	} else if strings.Contains(path, "*") {
+		_, paths, err = cmd.GetObjectsWildcard(path)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		paths = []string{path}
 	}
@@ -778,7 +783,21 @@ func (n *drawNode) execute() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return nil, cmd.Draw(path, n.depth, n.force)
+	if strings.Contains(path, "*") {
+		_, subpaths, err := cmd.GetObjectsWildcard(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, subpath := range subpaths {
+			err = cmd.Draw(subpath, n.depth, n.force)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	} else {
+		return nil, cmd.Draw(path, n.depth, n.force)
+	}
 }
 
 type undrawNode struct {

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -395,12 +395,23 @@ func (n *getObjectNode) execute() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	obj, err := cmd.GetObject(path)
-	if err != nil {
-		return nil, err
+	if strings.Contains(path, "*") {
+		objs, _, err := cmd.GetObjectsWildcard(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, obj := range objs {
+			cmd.DisplayObject(obj)
+		}
+		return objs, nil
+	} else {
+		obj, err := cmd.GetObject(path)
+		if err != nil {
+			return nil, err
+		}
+		cmd.DisplayObject(obj)
+		return obj, nil
 	}
-	cmd.DisplayObject(obj)
-	return obj, nil
 }
 
 type selectObjectNode struct {

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -424,7 +424,12 @@ func (n *selectObjectNode) execute() (interface{}, error) {
 		return nil, err
 	}
 	var selection []string
-	if path != "" {
+	if strings.Contains(path, "*") {
+		_, selection, err = cmd.GetObjectsWildcard(path)
+		if err != nil {
+			return nil, err
+		}
+	} else if path != "" {
 		selection = []string{path}
 		err = cmd.CD(path)
 		if err != nil {

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -210,6 +210,27 @@ func DeleteObj(path string) error {
 	return nil
 }
 
+func DeleteObjectsWildcard(path string) error {
+	objs, _, err := GetObjectsWildcard(path)
+	if err != nil {
+		return err
+	}
+	url, err := WilcardUrl(path)
+	if err != nil {
+		return err
+	}
+	_, err = RequestAPI("DELETE", url, nil, http.StatusNoContent)
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		if IsInObjForUnity(obj["category"].(string)) {
+			InformUnity("DeleteObj", -1, map[string]any{"type": "delete", "data": obj["id"].(string)})
+		}
+	}
+	return nil
+}
+
 func GetSlot(rack map[string]any, location string) (map[string]any, error) {
 	templateAny, ok := rack["attributes"].(map[string]any)["template"]
 	if !ok {


### PR DESCRIPTION
## Description

Allows to use wildcards when using the commands : get, draw, -, =, update (path:attr=value).
There is no recursive ** (glob) wildcard yet.

The feature works with a new route on the API side :
GET /api/objects-wildcard/{id-with-wildcard}
that returns a list of matching objects.

Fixes #40 

## Type of change
- [ x ] New feature (non-breaking change which adds functionality)
