### PR TITLE
feat(cli): message on empty selection

### DIFF
--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -420,7 +420,14 @@ func (n *selectObjectNode) execute() (interface{}, error) {
 			return nil, err
 		}
 	}
-	return cmd.SetClipBoard(selection)
+	_, err = cmd.SetClipBoard(selection)
+	if err != nil {
+		return nil, err
+	}
+	if len(selection) == 0 {
+		fmt.Println("Selection is now empty")
+	}
+	return nil, nil
 }
 
 func setRoomAreas(path string, values []any) (map[string]any, error) {
@@ -843,10 +850,12 @@ func (n *selectChildrenNode) execute() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if cmd.State.DebugLvl > cmd.NONE {
-		println("Selection made!")
-	}
+	if len(paths) == 0 {
+		fmt.Println("Selection is now empty")
 
+	} else if cmd.State.DebugLvl > cmd.NONE {
+		fmt.Println("Selection made")
+	}
 	return v, nil
 }
 

--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -335,8 +335,11 @@ func (p *parser) parsePathGroup() []node {
 	paths := []node{}
 	p.skipWhiteSpaces()
 	p.expect("{")
+	p.skipWhiteSpaces()
+	if p.parseExact("}") {
+		return paths
+	}
 	for {
-		p.skipWhiteSpaces()
 		paths = append(paths, p.parsePath(""))
 		p.skipWhiteSpaces()
 		if p.parseExact("}") {


### PR DESCRIPTION
## Description

A message is now printed when an empty selection is made.

Fixes #116 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
