### PR TITLE
chore(deploy) Replace sleep by mongo log check

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,7 +1,20 @@
+#!/bin/bash
+LOGFILE=/var/log/mongodb/mongodb.log
 openssl rand -base64 768 > /data/keyfile
 chmod 400 /data/keyfile && chown 999:999 /data/keyfile
-exec docker-entrypoint.sh mongod --bind_ip_all --replSet rs0 --keyFile /data/keyfile &
-sleep 10
+exec docker-entrypoint.sh mongod --bind_ip_all --replSet rs0 --keyFile /data/keyfile --logpath $LOGFILE &
+
+# Wait until mongo logs that it's ready
+while [ ! -f $LOGFILE ]
+do
+  sleep 2 
+done
+while [ ! "$(grep 'Waiting for connections' $LOGFILE)" ] ; do
+    sleep 2
+    echo "Waiting for mongo to initialize..."
+done
+
+# Initiate replicaSet
 mongosh -u admin -p adminpassword <<EOF
 rs.initiate({"_id": "rs0", "members": [{"_id": 1,"host": "$1:27017"}]});
 rs.status();


### PR DESCRIPTION
## Description

Replaces sleep 10 with log check to see hat mongo is up and running before try to initiate the replica set.

Fixes #157 

## Type of change

- Enhancement

## How Has This Been Tested?

- Local test with Docker and mongo images version 6 and 7