### PR TITLE
fix(cli): remove default clearance

### DIFF
--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -915,7 +915,6 @@ func CreateObject(path string, ent int, data map[string]interface{}) error {
 		baseAttrs := map[string]interface{}{
 			"sizeUnit":   "cm",
 			"heightUnit": "U",
-			"clearance":  Stringify([]float64{0., 0., 0., 0., 0.}),
 		}
 		if ent == CORRIDOR {
 			baseAttrs["heightUnit"] = "cm"


### PR DESCRIPTION
## Description
CLI does not add a default clearance attribute when creating racks anymore.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)
