### PR TITLE
fix(cli): dont print empty parsing stack on error

### DIFF
--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -140,19 +140,17 @@ func (p *parser) error(message string) {
 		errorStr += " "
 	}
 	errorStr += "\033[31m" + "^" + "\033[0m" + "\n"
-	if len(p.stackTrace) > 1 {
-		errorStr += "parsing stack : "
-		emptyStack := true
-		for i := range p.stackTrace {
-			if p.stackTrace[i].message != "" {
-				if !emptyStack {
-					errorStr += " -> "
-				}
-				errorStr += p.stackTrace[i].message
-				emptyStack = false
+	parsingStackStr := ""
+	for i := range p.stackTrace {
+		if p.stackTrace[i].message != "" {
+			if parsingStackStr != "" {
+				parsingStackStr += " -> "
 			}
+			parsingStackStr += p.stackTrace[i].message
 		}
-		errorStr += "\n"
+	}
+	if parsingStackStr != "" {
+		errorStr += "parsing stack : " + parsingStackStr + "\n"
 	}
 	errorStr += "\033[31m" + "Error : " + "\033[0m" + message
 	p.err = message


### PR DESCRIPTION
## Description

Even when the parsing stack was empty, sometimes "parsing stack : \n" was printed in the error message.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

