### PR TITLE
fix(cli): focus command crashing on empty path

### DIFF
--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -150,8 +150,7 @@ func (n *focusNode) execute() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd.FocusUI(path)
-	return nil, nil
+	return nil, cmd.FocusUI(path)
 }
 
 type cdNode struct {

--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -838,9 +838,6 @@ func (p *parser) parseCamera() node {
 
 func (p *parser) parseFocus() node {
 	defer un(trace(p, "focus"))
-	if p.commandEnd() {
-		return &focusNode{&valueNode{""}}
-	}
 	return &focusNode{p.parsePath("")}
 }
 


### PR DESCRIPTION
## Description

```
admin@alvea:/Physical/CAO/1SS/CVC12> >
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
cli/controllers.(*HierarchyNode).FindNode(0x0?, {0x0?, 0xc12cb0?})
        /workdir/controllers/tree.go:71 +0xc5
cli/controllers.Tree({0x0, 0x0}, 0xc000210240?)
        /workdir/controllers/tree.go:227 +0x3c
cli/controllers.CD({0x0, 0x0})
        /workdir/controllers/commandController.go:663 +0x66
cli/controllers.FocusUI({0x0, 0x0})
        /workdir/controllers/commandController.go:1432 +0x547
main.(*focusNode).execute(0xc0002d421c?)
        /workdir/ast.go:153 +0x3a
main.InterpretLine({0xc0002d421c?, 0xc00025a1e0?})
        /workdir/repl.go:29 +0x42
main.Start(0xc000214150, {0xc00000ad9a, 0x5})
        /workdir/repl.go:54 +0x7a
main.main()
        /workdir/main.go:82 +0x83f
```

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- parser unit tests
