### PR TITLE
fix(cli): tree error with imbricated domains

### DIFF
--- a/CLI/controllers/tree.go
+++ b/CLI/controllers/tree.go
@@ -183,6 +183,10 @@ func FillUrlTree(n *HierarchyNode, path string, depth int, url string, followFil
 		if err != nil {
 			return invalidRespErr
 		}
+		objId, okId := obj["id"].(string)
+		if okId && objId != objName {
+			continue
+		}
 		subTree := NewNode(objName)
 		subTree.FillFn = followFillFn
 		err = FillTree(subTree, path+"/"+objName, depth-1)


### PR DESCRIPTION
## Description
```
>tree / 5
Error : location not found
```
when using tree with imbricated domains, because the /api/domains route was assumed to return only the root domains, which is not the case.

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

