### PR TITLE
fix(cli): empty /Logical/Groups

### DIFF
--- a/CLI/controllers/tree.go
+++ b/CLI/controllers/tree.go
@@ -181,10 +181,10 @@ func FillUrlTree(n *HierarchyNode, path string, depth int, url string, followFil
 			objName = strings.Replace(obj["id"].(string), ".", "/", -1)
 		} else {
 			objName = nameOrSlug(obj)
-		}
-		objId, okId := obj["id"].(string)
-		if okId && objId != objName {
-			continue
+			objId, okId := obj["id"].(string)
+			if okId && objId != objName {
+				continue
+			}
 		}
 		subTree := NewNode(objName)
 		subTree.FillFn = followFillFn


### PR DESCRIPTION
## Description

A previous fix (PR #210) caused that bug that prevents groups from showing in /Logical/Groups

## Type of change

- Bug fix (non-breaking change which fixes an issue)

