### PR TITLE
fix(cli): alias call parsing bug

### DIFF
--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -213,6 +213,7 @@ func (p *parser) parseKeyWord(candidates []string) string {
 	if sliceContains(candidates, p.item(false)) {
 		return p.item(false)
 	}
+	p.reset()
 	return ""
 }
 


### PR DESCRIPTION
## Description

When calling an alias, sometimes the first characters were ignored, causing the call to fail because of undefined function.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Parser unit tests
