### PR TITLE
[SuperAdmin] Launch scripts: handle container already exists

### DIFF
--- a/APP/Dockerfile
+++ b/APP/Dockerfile
@@ -25,5 +25,5 @@ RUN flutter pub get
 RUN flutter build web 
 
 # Runtime image
-FROM nginx:1.21.1-alpine
+FROM nginx:1.24.0-alpine
 COPY --from=build /app/build/web /usr/share/nginx/html

--- a/APP/README.md
+++ b/APP/README.md
@@ -9,13 +9,7 @@ To quickly deploy a frontend and docker backend in SuperAdmin mode, just execute
 # Linux 
 ./launch.sh
 ```
-This will launch the webapp on port 8080 and backend on port 8082. To set different ports:
-```console
-# Windows (use PowerShell)
-.\launch.ps1 -portWeb XXXX -portBack YYYY
-# Linux 
-./launch.sh -w XXXX -b YYYY
-```
+For more options, check the documentation under `deploy/`.
 
 ## Flutter Frontend
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -62,7 +62,15 @@ To quickly deploy a frontend and docker backend in SuperAdmin mode, just execute
 ./launch.sh
 ```
 
-This will launch the webapp on port 8080 and backend on port 8082. To set different ports:
+If a frontend was already created with a previous run of this script and has allocated the default port, add `-f` option to force run the new container, stopping the old one without removing it:
+```console
+# Windows (use PowerShell)
+.\launch.ps1 -f
+# Linux 
+./launch.sh -f
+```
+
+The default is to launch the webapp on port 8080 and backend on port 8082. To set different ports:
 
 ```console
 # Windows (use PowerShell)

--- a/deploy/app/launch.ps1
+++ b/deploy/app/launch.ps1
@@ -1,18 +1,38 @@
 param (
     [string]$portWeb = "8080",
-    [string]$portBack = "8081"
+    [string]$portBack = "8081",
+    [switch]$f
  )
 
+ # build front container
 cd ..\..\APP
 docker build . -t ogree-app
 $assetsDir = "${PWD}\assets\custom"
 $file = "${assetsDir}\.env"
 (Get-Content $file) -replace '8081', $portBack | Set-Content $file
-docker run --restart always --name ogree-superadmin -p ${portWeb}:80 -v ${assetsDir}:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
+
+# run container
+$basename = "ogree-superadmin"
+$containername = $basename
+$index = 1
+While ($null -ne (docker ps --all --format "{{json .}}" --filter "name=$containername"))
+{
+    Write-Host "Container $containername already exists"
+    if ($f.IsPresent) {
+        Write-Host "Stopping it if running"
+        docker stop $containername
+    }
+    $containername = "$basename-$index"
+    $index++
+}
+
+Write-Host "Launch $containername container"
+docker run --restart always --name $containername -p ${portWeb}:80 -v ${assetsDir}:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
 if ($LASTEXITCODE -ne 0) {
     Write-Host "UNABLE TO LAUNCH WEBAPP CONTAINER, CHECK ERROR ABOVE" -ForegroundColor red
 }
 
+# compile and run back
 cd ..\BACK\docker-backend
 docker run --rm -v ${PWD}:/workdir -w /workdir -e GOOS=windows golang go build -o ogree_app_backend.exe
 .\ogree_app_backend.exe -port $portBack

--- a/deploy/app/launch.sh
+++ b/deploy/app/launch.sh
@@ -26,6 +26,7 @@ index=1
 while [[ $(docker ps --all --format "{{json .}}" | grep $containername) ]]; do
     echo "Container $containername already exists"
     if $forceStop; then
+        echo "Stopping it if running"
         docker stop $containername
     fi
     containername="$basename-$index"

--- a/deploy/app/launch.sh
+++ b/deploy/app/launch.sh
@@ -2,21 +2,41 @@
 
 portWeb=8080
 portBack=8082
-while getopts w:b: flag
+forceStop=false
+while getopts w:b:f flag
 do
     case "$flag" in
         w) portWeb=${OPTARG};;
         b) portBack=${OPTARG};;
+        f) forceStop=true;;
     esac
 done
 
+# build front container
 cd ../../APP
 assetsDir="$(pwd)/assets/custom"
 file="$assetsDir/.env"
 docker build . -t ogree-app
 sed -i "s/8081/$portBack/g" $file
-docker run --restart always --name ogree-superadmin -p $portWeb:80 -v $assetsDir:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
 
+# run container
+basename="ogree-superadmin"
+containername=$basename
+index=1
+while [[ $(docker ps --all --format "{{json .}}" | grep $containername) ]]; do
+    echo "Container $containername already exists"
+    if $forceStop; then
+        docker stop $containername
+    fi
+    containername="$basename-$index"
+    ((index++))
+done
+
+
+echo "Launch $containername container"
+docker run --restart always --name $containername -p $portWeb:80 -v $assetsDir:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
+
+# compile and run back
 cd ../BACK/docker-backend
 docker run --rm -v $(pwd):/workdir -w /workdir golang go build -o ogree_app_backend
 ./ogree_app_backend -port $portBack


### PR DESCRIPTION
## Description

If a container with the same name already exists an incrementable suffix -X will be added as needed (ogree-superadmin-1, for example). A -f option was added to stop previous containers, releasing the allocated port.

Fixes #253

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test with bash and powershell
