### PR TITLE
fix(cli): printf syntax + man page

### DIFF
--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -663,7 +663,7 @@ func Help(entry string) {
 	var path string
 	entry = strings.TrimSpace(entry)
 	switch entry {
-	case "ls", "pwd", "print", "cd", "tree", "get", "clear",
+	case "ls", "pwd", "print", "printf", "cd", "tree", "get", "clear",
 		"lsog", "grep", "for", "while", "if", "env",
 		"cmds", "var", "unset", "selection", commands.Connect3D, "camera", "ui", "hc", "drawable",
 		"link", "unlink", "draw", "getu", "getslot", "undraw",

--- a/CLI/other/man/print.md
+++ b/CLI/other/man/print.md
@@ -1,11 +1,11 @@
-USAGE: print  \"anything you want\"   
-Prints data to output   
+USAGE: print [value]
+where [value] can be either 
+* a string (in which dereferencing variables is possible, or produced by the format function)
+* the evaluation of an expression via: eval [expr]
+* the result of a command via $(([command]))
 
-NOTE   
-print command will not perform arithmetic or any other calculation on it's arguments and will print them directly with the exception of concatenate which is still primitive. Thus printing "hey""another will return "hey""another. Multiple arguments are only supported if concatenated within quotes.    
-
-EXAMPLE   
-
-    print "Welcome to OGrEE"   
-    print $x
-    print "$x/another/path"
+EXAMPLE
+    print hello world // prints "hello world"
+    print 41 + 1 // prints "41 + 1"
+    print eval 41 + 1 // prints "42"
+    print format("41 + 1 equals %d", 42) // prints "41 + 1 equals 42"

--- a/CLI/other/man/printf.md
+++ b/CLI/other/man/printf.md
@@ -1,0 +1,7 @@
+USAGE: printf [format], [arg1], ..., [argn]
+Where [format] is an expression returning a string, that can include format specifiers (subsequences beginning with %).
+Each [arg] is an expression returning a value that will replace the corresponding format specifier.
+For more details about the format specifiers, see https://pkg.go.dev/fmt.
+
+EXAMPLE
+    printf "41 + 1 equals %03d", 42 // prints "41 + 1 equals 042"

--- a/CLI/parser_test.go
+++ b/CLI/parser_test.go
@@ -344,6 +344,7 @@ var commandsMatching = map[string]node{
 	".cmds:${CUST}/DEMO.PERF.ocli":           &loadNode{&formatStringNode{&valueNode{"%v/DEMO.PERF.ocli"}, []node{&symbolReferenceNode{"CUST"}}}},
 	".cmds:${a}/${b}.ocli":                   &loadNode{&formatStringNode{&valueNode{"%v/%v.ocli"}, []node{&symbolReferenceNode{"a"}, &symbolReferenceNode{"b"}}}},
 	"while $i<6 {print \"a\"}":               &whileNode{&comparatorNode{"<", &symbolReferenceNode{"i"}, &valueNode{6}}, &printNode{&valueNode{"a"}}},
+	"printf \"coucou %d\", 12":               &printNode{&formatStringNode{&valueNode{"coucou %d"}, []node{&valueNode{12}}}},
 }
 
 func TestSimpleCommands(t *testing.T) {


### PR DESCRIPTION
## Description

Removes the parenthesis from the printf, they were causing a bug because of the inconsistency with other commands.
```
printf "41 + 1 equals %03d", 42
```
Also adds the printf man page, and improves print one.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation

## How Has This Been Tested?

- Unit tests
