### PR TITLE
fix(cli): show error on get not existent object

### DIFF
--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -7,6 +7,7 @@ import (
 	cmd "cli/controllers"
 	"cli/utils"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -430,6 +431,11 @@ func (n *getObjectNode) execute() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if !strings.Contains(path, "*") && len(objs) == 0 {
+		return nil, errors.New("object not found")
+	}
+
 	for _, obj := range objs {
 		cmd.DisplayObject(obj)
 	}


### PR DESCRIPTION
## Description

fix bug present since the merge of filtering ls, from which when you get an object that does not exist (get asd for example) it does not show an error message. The error message is only added when the requested path does not have a wildcard, since in that case I do not consider the empty response to be an error.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test on cli
