### PR TITLE
Propagate domain ID changes to objects

### DIFF
--- a/API/models/model.go
+++ b/API/models/model.go
@@ -98,26 +98,26 @@ func PropagateParentIdChange(ctx context.Context, oldParentId, newId string, ent
 					"find":        oldParentId,
 					"replacement": newId}}}}}
 	if entityInt == u.DOMAIN {
-		_, e := repository.GetDB().Collection(u.EntityToString(u.DOMAIN)).UpdateMany(ctx,
+		_, err := repository.GetDB().Collection(u.EntityToString(u.DOMAIN)).UpdateMany(ctx,
 			req, mongo.Pipeline{update})
-		if e != nil {
-			println(e.Error())
-			return e
+		if err != nil {
+			println(err.Error())
+			return err
 		}
 	} else if entityInt == u.DEVICE {
-		_, e := repository.GetDB().Collection(u.EntityToString(u.DEVICE)).UpdateMany(ctx,
+		_, err := repository.GetDB().Collection(u.EntityToString(u.DEVICE)).UpdateMany(ctx,
 			req, mongo.Pipeline{update})
-		if e != nil {
-			println(e.Error())
-			return e
+		if err != nil {
+			println(err.Error())
+			return err
 		}
 	} else {
 		for i := entityInt + 1; i <= u.GROUP; i++ {
-			_, e := repository.GetDB().Collection(u.EntityToString(i)).UpdateMany(ctx,
+			_, err := repository.GetDB().Collection(u.EntityToString(i)).UpdateMany(ctx,
 				req, mongo.Pipeline{update})
-			if e != nil {
-				println(e.Error())
-				return e
+			if err != nil {
+				println(err.Error())
+				return err
 			}
 		}
 	}
@@ -137,11 +137,10 @@ func PropagateDomainChange(ctx context.Context, oldDomainId, newDomainId string)
 					"find":        oldDomainId,
 					"replacement": newDomainId}}}}}
 	for i := u.STRAYOBJ; i <= u.GROUP; i++ {
-		_, e := repository.GetDB().Collection(u.EntityToString(i)).UpdateMany(ctx,
+		_, err := repository.GetDB().Collection(u.EntityToString(i)).UpdateMany(ctx,
 			req, mongo.Pipeline{update})
-		if e != nil {
-			println(e.Error())
-			return e
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/API/models/model.go
+++ b/API/models/model.go
@@ -136,7 +136,7 @@ func PropagateDomainChange(ctx context.Context, oldDomainId, newDomainId string)
 					"input":       "$domain",
 					"find":        oldDomainId,
 					"replacement": newDomainId}}}}}
-	for i := u.STRAYOBJ + 1; i <= u.GROUP; i++ {
+	for i := u.STRAYOBJ; i <= u.GROUP; i++ {
 		_, e := repository.GetDB().Collection(u.EntityToString(i)).UpdateMany(ctx,
 			req, mongo.Pipeline{update})
 		if e != nil {


### PR DESCRIPTION
## Description

Changes to the name of the domain imply changing its id which is used as reference by other objects so now it propagated to them as well. 

Fixes #287

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test using Postman
