### PR TITLE
Unify elemOrient on object template schema

### DIFF
--- a/API/models/schemas/obj_template_schema.json
+++ b/API/models/schemas/obj_template_schema.json
@@ -109,108 +109,48 @@
         "slug": {
             "type": "string",
             "pattern": "^[a-zA-Z0-9-]+$"
-        }
-    },
-    "if": {
-        "properties": {
-            "category": {
-                "const": "rack"
-            }
-        }
-    },
-    "then": {
-        "properties": {
-            "slots": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": [
-                        "elemOrient",
-                        "elemPos",
-                        "elemSize",
-                        "labelPos",
-                        "location",
-                        "type"
-                    ],
-                    "properties": {
-                        "elemOrient": {
-                            "type": "string",
-                            "enum": [
-                                "horizontal",
-                                "vertical"
-                            ]
-                        },
-                        "attributes": {
-                            "$ref": "#/$defs/attributes"
-                        },
-                        "color": {
-                            "$ref": "#/$defs/color"
-                        },
-                        
-                        "elemPos": {
-                            "$ref": "#/$defs/elemPos"
-                        },
-                        "elemSize": {
-                            "$ref": "#/$defs/elemSize"
-                        },
-                        "labelPos": {
-                            "$ref": "#/$defs/labelPos"
-                        },
-                        "location": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "else": {
-        "properties": {
-            "slots": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": [
-                        "elemPos",
-                        "elemSize",
-                        "labelPos",
-                        "location",
-                        "type"
-                    ],
-                    "properties": {
-                        "elemOrient": {
-                            "type": "string",
-                            "enum": [
-                                "horizontal",
-                                "vertical",
-                                ""
-                            ]
-                        },
-                        "attributes": {
-                            "$ref": "#/$defs/attributes"
-                        },
-                        "color": {
-                            "$ref": "#/$defs/color"
-                        },
-                        
-                        "elemPos": {
-                            "$ref": "#/$defs/elemPos"
-                        },
-                        "elemSize": {
-                            "$ref": "#/$defs/elemSize"
-                        },
-                        "labelPos": {
-                            "$ref": "#/$defs/labelPos"
-                        },
-                        "location": {
-                            "type": "string"
-                        },
-                        "type": {
-                            "type": "string"
-                        }
+        },
+        "slots": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "elemOrient",
+                    "elemPos",
+                    "elemSize",
+                    "labelPos",
+                    "location",
+                    "type"
+                ],
+                "properties": {
+                    "elemOrient": {
+                        "type": "string",
+                        "enum": [
+                            "horizontal",
+                            "vertical"
+                        ]
+                    },
+                    "attributes": {
+                        "$ref": "#/$defs/attributes"
+                    },
+                    "color": {
+                        "$ref": "#/$defs/color"
+                    },
+                    
+                    "elemPos": {
+                        "$ref": "#/$defs/elemPos"
+                    },
+                    "elemSize": {
+                        "$ref": "#/$defs/elemSize"
+                    },
+                    "labelPos": {
+                        "$ref": "#/$defs/labelPos"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
                     }
                 }
             }
@@ -291,7 +231,7 @@
                 {
                     "location": "cpu1",
                     "type": "processor",
-                    "elemOrient": "",
+                    "elemOrient": "horizontal",
                     "elemPos": [68, 343, 0],
                     "elemSize": [97, 97, 30],
                     "mandatory": "yes",

--- a/API/models/schemas/test_data/KO/obj_template4.json
+++ b/API/models/schemas/test_data/KO/obj_template4.json
@@ -19,8 +19,8 @@
 
     "slots"  : [
     { "location": "blade01",  "type": "blade",   "elemOrient" : "banana", "elemPos" : [225,260, 0],  "elemSize" : [225,660, 45], "labelPos" : "front" },
-    { "location": "blade02",  "type": "blade",   "elemPos" : [  0,260, 0],  "elemSize" : [225,660, 45], "labelPos" : "front" },
-    { "location": "blade03",  "type": "blade",   "elemOrient" : "", "elemPos" : [225,260,45],  "elemSize" : [225,660, 45], "labelPos" : "front", "color" : "" }
+    { "location": "blade02",  "type": "blade",   "elemOrient" : "vertical", "elemPos" : [  0,260, 0],  "elemSize" : [225,660, 45], "labelPos" : "front" },
+    { "location": "blade03",  "type": "blade",   "elemOrient" : "horizontal", "elemPos" : [225,260,45],  "elemSize" : [225,660, 45], "labelPos" : "front", "color" : "" }
         ]
             ,
     "sensors"  : [

--- a/API/models/schemas/test_data/OK/obj_template1.json
+++ b/API/models/schemas/test_data/OK/obj_template1.json
@@ -327,7 +327,7 @@
         {
             "location": "blade01",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 225,
                 260,
@@ -344,7 +344,7 @@
         {
             "location": "blade02",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 0,
                 260,
@@ -361,7 +361,7 @@
         {
             "location": "blade03",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 225,
                 260,
@@ -378,7 +378,7 @@
         {
             "location": "blade04",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 0,
                 260,
@@ -395,7 +395,7 @@
         {
             "location": "blade05",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 225,
                 260,
@@ -412,7 +412,7 @@
         {
             "location": "blade06",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 0,
                 260,
@@ -429,7 +429,7 @@
         {
             "location": "blade07",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 225,
                 260,
@@ -446,7 +446,7 @@
         {
             "location": "blade08",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 0,
                 260,
@@ -463,7 +463,7 @@
         {
             "location": "blade09",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 225,
                 260,
@@ -480,7 +480,7 @@
         {
             "location": "blade10",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 0,
                 260,
@@ -497,7 +497,7 @@
         {
             "location": "blade11",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 225,
                 260,
@@ -514,7 +514,7 @@
         {
             "location": "blade12",
             "type": "blade",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 0,
                 260,

--- a/API/models/schemas/test_data/OK/obj_template3.json
+++ b/API/models/schemas/test_data/OK/obj_template3.json
@@ -84,7 +84,7 @@
         {
             "location": "cpu1",
             "type": "processor",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 68,
                 343,
@@ -105,7 +105,7 @@
         {
             "location": "cpu2",
             "type": "processor",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 53,
                 223,
@@ -126,7 +126,7 @@
         {
             "location": "dimm1",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 200,
                 336,
@@ -147,7 +147,7 @@
         {
             "location": "dimm2",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 190,
                 336,
@@ -168,7 +168,7 @@
         {
             "location": "dimm4",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 180,
                 336,
@@ -189,7 +189,7 @@
         {
             "location": "dimm3",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 170,
                 336,
@@ -210,7 +210,7 @@
         {
             "location": "dimm5",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 64,
                 336,
@@ -231,7 +231,7 @@
         {
             "location": "dimm6",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 54,
                 336,
@@ -252,7 +252,7 @@
         {
             "location": "dimm7",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 44,
                 336,
@@ -273,7 +273,7 @@
         {
             "location": "dimm8",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 34,
                 336,
@@ -294,7 +294,7 @@
         {
             "location": "dimm9",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "vertical",
             "elemPos": [
                 190,
                 194,
@@ -315,7 +315,7 @@
         {
             "location": "dimm10",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 180,
                 194,
@@ -336,7 +336,7 @@
         {
             "location": "dimm11",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 170,
                 194,
@@ -357,7 +357,7 @@
         {
             "location": "dimm12",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 160,
                 194,
@@ -378,7 +378,7 @@
         {
             "location": "dimm13",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 45,
                 194,
@@ -399,7 +399,7 @@
         {
             "location": "dimm14",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 35,
                 194,
@@ -420,7 +420,7 @@
         {
             "location": "dimm15",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 25,
                 194,
@@ -441,7 +441,7 @@
         {
             "location": "dimm16",
             "type": "memory",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 15,
                 194,
@@ -462,7 +462,7 @@
         {
             "location": "slot2",
             "type": "adapter",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 153,
                 493,
@@ -483,7 +483,7 @@
         {
             "location": "slot1",
             "type": "adapter",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 29,
                 485,
@@ -504,7 +504,7 @@
         {
             "location": "eth1imm",
             "type": "port",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 86,
                 649,
@@ -525,7 +525,7 @@
         {
             "location": "imm2",
             "type": "port",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 162,
                 649,
@@ -546,7 +546,7 @@
         {
             "location": "eth2",
             "type": "port",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 104,
                 649,
@@ -567,7 +567,7 @@
         {
             "location": "hdd182",
             "type": "disk",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 152,
                 72,
@@ -588,7 +588,7 @@
         {
             "location": "hdd183",
             "type": "disk",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 152,
                 72,
@@ -609,7 +609,7 @@
         {
             "location": "hdd184",
             "type": "disk",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 152,
                 72,
@@ -630,7 +630,7 @@
         {
             "location": "hdd251",
             "type": "disk",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 136,
                 50,
@@ -651,7 +651,7 @@
         {
             "location": "hdd252",
             "type": "disk",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 136,
                 50,
@@ -672,7 +672,7 @@
         {
             "location": "hdd351",
             "type": "disk",
-            "elemOrient": "",
+            "elemOrient": "horizontal",
             "elemPos": [
                 104,
                 3,

--- a/API/models/validateEntity_test.go
+++ b/API/models/validateEntity_test.go
@@ -70,7 +70,6 @@ func TestErrorValidateJsonSchema(t *testing.T) {
 		"obj_template5": {
 			"/slug does not match pattern",
 			"/attributes/vendor expected string, but got number",
-			"if-then failed",
 			"/slots/0/elemOrient value must be one of ",
 			"/slots/1/elemPos maximum 3 items required, but found 4 items",
 			"/slots/1/elemSize minimum 3 items required, but found 2 items",
@@ -84,7 +83,6 @@ func TestErrorValidateJsonSchema(t *testing.T) {
 			"/components/1/elemOrient value must be one of",
 			"/components/1/color does not match pattern",
 			"/components/3/labelPos value must be one of",
-			"if-else failed",
 			"/slots/0/elemOrient value must be one of",
 		},
 		"bldg_template2": {


### PR DESCRIPTION
## Description

Unify elemOrient for racks and devices, making it required with only two values accepted.

Fixes #316

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test using Postman
