### PR TITLE
Disable autosave history for confirmation

### DIFF
--- a/CLI/controllers/draw.go
+++ b/CLI/controllers/draw.go
@@ -29,7 +29,9 @@ func (controller Controller) Draw(path string, depth int, force bool) error {
 				"Do you want to continue ? (y/n)\n"
 			(*State.Terminal).Write([]byte(msg))
 			(*State.Terminal).SetPrompt(">")
+			(*State.Terminal).Operation.SetDisableAutoSaveHistory(true)
 			ans, _ := (*State.Terminal).Readline()
+			(*State.Terminal).Operation.SetDisableAutoSaveHistory(false)
 			if ans != "y" && ans != "Y" {
 				okToGo = false
 			}

--- a/CLI/readline/operation.go
+++ b/CLI/readline/operation.go
@@ -481,6 +481,12 @@ func (o *Operation) SetHistoryPath(path string) {
 	o.history = newOpHistory(o.cfg)
 }
 
+func (o *Operation) SetDisableAutoSaveHistory(valeur bool) {
+	o.m.Lock()
+	o.cfg.DisableAutoSaveHistory = valeur
+	o.m.Unlock()
+}
+
 func (o *Operation) IsNormalMode() bool {
 	return !o.IsInCompleteMode() && !o.IsSearchMode()
 }


### PR DESCRIPTION
## Description

The command draw may ask user for confirmation. The answer (y/Y to accept, or any other thing to reject) is no longer registered in the history.

Fixes #285

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test 
