### PR TITLE
fix(cli) deleted object not removed

### DIFF
--- a/CLI/controllers/delete.go
+++ b/CLI/controllers/delete.go
@@ -24,6 +24,9 @@ func (controller Controller) DeleteObj(path string) ([]string, error) {
 		} else if models.IsTag(path) && IsEntityTypeForOGrEE3D(models.TAG) {
 			controller.Ogree3D.InformOptional("DeleteObj", -1, map[string]any{"type": "delete-tag", "data": obj["slug"].(string)})
 		}
+		if models.IsLayer(path) {
+			State.Hierarchy.Children["Logical"].Children["Layers"].IsCached = false
+		}
 	}
 	if path == State.CurrPath {
 		controller.CD(TranslatePath("..", false))

--- a/CLI/controllers/tree.go
+++ b/CLI/controllers/tree.go
@@ -374,7 +374,7 @@ func FillUrlTree[T any](n *HierarchyNode, api APIPort, path string, depth int, u
 		return invalidRespErr
 	}
 
-	if _, ok := n.Children["Stray"]; ok {
+	if _, ok := n.Children["Stray"]; ok && n.Name == "Physical" {
 		n.Children = map[string]*HierarchyNode{"Stray": n.Children["Stray"]}
 	} else {
 		n.Children = map[string]*HierarchyNode{}

--- a/CLI/controllers/tree.go
+++ b/CLI/controllers/tree.go
@@ -227,6 +227,10 @@ func (n *HierarchyNode) Fill(path string, depth int, now time.Time) error {
 
 	n.LastHierarchyGet = now
 
+	if n.Name == "Layers" {
+		n.IsCached = true
+	}
+
 	if n.FillFn != nil {
 		return n.FillFn(n, path, depth)
 	}
@@ -363,6 +367,12 @@ func FillUrlTree[T any](n *HierarchyNode, api APIPort, path string, depth int, u
 	objects, hasObjects := data["objects"].([]any)
 	if !hasObjects {
 		return invalidRespErr
+	}
+
+	if _, ok := n.Children["Stray"]; ok {
+		n.Children = map[string]*HierarchyNode{"Stray": n.Children["Stray"]}
+	} else {
+		n.Children = map[string]*HierarchyNode{}
 	}
 
 	for _, objAny := range objects {

--- a/CLI/controllers/tree.go
+++ b/CLI/controllers/tree.go
@@ -240,6 +240,11 @@ func (n *HierarchyNode) Fill(path string, depth int, now time.Time) error {
 
 func (n *HierarchyNode) FillWithMap(obj map[string]any) error {
 	children, hasChildren := obj["children"].([]any)
+
+	if len(n.Children) != 0 {
+		n.Children = map[string]*HierarchyNode{}
+	}
+
 	if hasChildren {
 		delete(obj, "children")
 


### PR DESCRIPTION
## Description

- Updated `/Logical/Layers` caching logic, preventing `ls` from showing deleted layers;
- Updated `FillUrlTree` and `FillWithMap` logic to reset original node's children list before refilling it, preventing `ls` from showing deleted objects.

Fixes #315 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test creating and deleting objects and calling `ls` to see if they are still listed or not.
