### PR TITLE
fix(cli) empty for loop causes segfault

### DIFF
--- a/CLI/astflow.go
+++ b/CLI/astflow.go
@@ -135,6 +135,9 @@ func (n *forRangeNode) execute() (interface{}, error) {
 	}
 	for i := start; i <= end; i++ {
 		c.State.DynamicSymbolTable[n.variable] = i
+		if n.body == nil {
+			return nil, fmt.Errorf("loop body should not be empty")
+		}
 		_, err = n.body.execute()
 		if err != nil {
 			return nil, err

--- a/wiki/CLI-language.md
+++ b/wiki/CLI-language.md
@@ -129,7 +129,7 @@ They can be used to build more complex expressions through operators.
 ## Operators
 ### Compute operators : 
 these will only work if both side return a number  
-+, -, *, /, // (integer division), % (modulo)
++, -, *, /, \ (integer division), % (modulo)
 ### Boolean operators : 
 <, >, <=, >=, ==, !=, || (or), && (and) 
 


### PR DESCRIPTION
## Description

- Fixes #330 - Added a simple check to verify wether the loop body is empty or not before executing it, avoiding the segfault;

- Fixes #329 - Corrected the integer division operator on the wiki.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test