### PR TITLE
feat(API) Better error messages on invalid ParentID

### DIFF
--- a/API/models/create_object_test.go
+++ b/API/models/create_object_test.go
@@ -101,7 +101,7 @@ func TestCreateGenericWithParentNotRoomReturnsError(t *testing.T) {
 
 	_, err := integration.CreateGeneric(rack["id"].(string), "create-object-8-generic")
 	assert.NotNil(t, err)
-	assert.ErrorContains(t, err, "ParentID should correspond to Existing Room ID")
+	assert.ErrorContains(t, err, "ParentID should correspond to existing room ID")
 }
 
 func TestCreateGenericWithParentRoomWorks(t *testing.T) {

--- a/API/models/validateEntity.go
+++ b/API/models/validateEntity.go
@@ -89,17 +89,9 @@ func validateParent(ent string, entNum int, t map[string]interface{}) (map[strin
 		}
 
 		return nil, &u.Error{Type: u.ErrInvalidValue,
-			Message: "ParentID should correspond to Existing Rack or Device ID"}
+			Message: "ParentID should correspond to existing rack or device ID"}
 
 	case u.GROUP:
-		w, _ := GetObject(req, "device", u.RequestFilters{}, nil)
-		if w != nil {
-			parent["parent"] = "device"
-			parent["domain"] = w["domain"]
-			parent["id"] = w["id"]
-			return parent, nil
-		}
-
 		x, _ := GetObject(req, "rack", u.RequestFilters{}, nil)
 		if x != nil {
 			parent["parent"] = "rack"
@@ -125,7 +117,7 @@ func validateParent(ent string, entNum int, t map[string]interface{}) (map[strin
 		}
 
 		return nil, &u.Error{Type: u.ErrInvalidValue,
-			Message: "ParentID should correspond to Existing ID"}
+			Message: "ParentID should correspond to existing rack, room or building ID"}
 
 	case u.GENERIC:
 		x, _ := GetObject(req, "room", u.RequestFilters{}, nil)
@@ -137,7 +129,7 @@ func validateParent(ent string, entNum int, t map[string]interface{}) (map[strin
 		}
 
 		return nil, &u.Error{Type: u.ErrInvalidValue,
-			Message: "ParentID should correspond to Existing Room ID"}
+			Message: "ParentID should correspond to existing room ID"}
 	default:
 		parentInt := u.GetParentOfEntityByInt(entNum)
 		parentStr := u.EntityToString(parentInt)
@@ -151,8 +143,9 @@ func validateParent(ent string, entNum int, t map[string]interface{}) (map[strin
 		} else if err != nil {
 			println("ENTITY VALUE: ", ent)
 			println("We got Parent: ", parent, " with ID:", t["parentId"].(string))
+			fmt.Printf("parent should be %v\n", u.EntityToString(parentInt))
 			return nil, &u.Error{Type: u.ErrInvalidValue,
-				Message: "ParentID should correspond to Existing ID"}
+				Message: fmt.Sprintf("ParentID should correspond to existing %s ID", parentStr)}
 		}
 	}
 	return nil, nil

--- a/API/models/validateEntity.go
+++ b/API/models/validateEntity.go
@@ -143,7 +143,6 @@ func validateParent(ent string, entNum int, t map[string]interface{}) (map[strin
 		} else if err != nil {
 			println("ENTITY VALUE: ", ent)
 			println("We got Parent: ", parent, " with ID:", t["parentId"].(string))
-			fmt.Printf("parent should be %v\n", u.EntityToString(parentInt))
 			return nil, &u.Error{Type: u.ErrInvalidValue,
 				Message: fmt.Sprintf("ParentID should correspond to existing %s ID", parentStr)}
 		}


### PR DESCRIPTION
## Description

- Edit error messages on function `validateParent` to inform what should be the parent category of an object being created in an incorrect place.

- Removes `device` from list of possible parents of a `u.GROUP`.

Fixes #303 .

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test.