### PR TITLE
Fix missing build info from API

### DIFF
--- a/API/Dockerfile
+++ b/API/Dockerfile
@@ -7,10 +7,11 @@ WORKDIR /home
 
 RUN apt install git
 
-COPY go.mod go.sum /home/
+COPY API/go.mod API/go.sum /home/
 RUN go mod download
 
-COPY . .git* /home/
+COPY API/ /home/
+COPY .git /home/
 
 #Build
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -20,6 +21,6 @@ FROM busybox:latest
 USER root
 WORKDIR /home
 
-COPY resources/test/ /home/resources/test/
+COPY API/resources/test/ /home/resources/test/
 COPY --from=builder /home/main /home
 ENTRYPOINT [ "/home/main" ]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ${CORE_DIR}
       dockerfile: ${API_BUILD_DIR}/Dockerfile
+      args:
+        BUILDKIT_CONTEXT_KEEP_GIT_DIR: true
     image: ogree/api:${IMAGE_TAG}
     container_name: ${COMPOSE_PROJECT_NAME}_api
     environment:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.9'
 services:
   ogree_api:
     build:
-      context: ${CORE_DIR}/${API_BUILD_DIR}
+      context: ${CORE_DIR}
+      dockerfile: ${API_BUILD_DIR}/Dockerfile
     image: ogree/api:${IMAGE_TAG}
     container_name: ${COMPOSE_PROJECT_NAME}_api
     environment:


### PR DESCRIPTION
## Description

Corrects the answer of /api/version showing build info, displayed by the CLI when lsog is called.

Fixes #345

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test 
