### PR TITLE
fix(CLI) Tag creation should not accept a hex value with less than 6 digits

### DIFF
--- a/CLI/utils/util.go
+++ b/CLI/utils/util.go
@@ -168,10 +168,6 @@ func ValToColor(color interface{}) (string, bool) {
 			colorStr = strconv.FormatFloat(color.(float64), 'f', -1, 64)
 		}
 
-		for len(colorStr) < 6 {
-			colorStr = "0" + colorStr
-		}
-
 		if len(colorStr) != 6 {
 			return "", false
 		}

--- a/wiki/CLI-language.md
+++ b/wiki/CLI-language.md
@@ -78,7 +78,6 @@
   - [Loops](#loops)
   - [Aliases](#aliases)
 - [Examples](#examples)
->>>>>>> b24e621b (docs(cli): create generic and generic template)
 - [Glossary](#glossary)
 - [Comments](#comments)
 - [Variables](#variables)


### PR DESCRIPTION
## Description

- Removed logic to append zeroes to the left of a tag color;

- Removed unnecessary line on `CLI Language` Wiki page.

- Fixes #353 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test
