### PR TITLE
fix(CLI) corrected `labelBackground` command behavior

### DIFF
--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -510,6 +510,17 @@ func setLabelFont(path string, values []any) (map[string]any, error) {
 	}
 }
 
+func setLabelBackground(path string, values []any) (map[string]any, error) {
+	if len(values) != 1 {
+		return nil, fmt.Errorf("only 1 value expected")
+	}
+	c, ok := utils.ValToColor(values[0])
+	if !ok {
+		return nil, fmt.Errorf("please provide a valid 6 length hex value for the color")
+	}
+	return nil, cmd.C.InteractObject(path, "labelBackground", c, false)
+}
+
 func addToStringMap[T any](stringMap string, key string, val T) (string, bool) {
 	m := map[string]T{}
 	if stringMap != "" {
@@ -744,6 +755,8 @@ func (n *updateObjNode) execute() (interface{}, error) {
 				_, err = setLabel(path, values, n.hasSharpe)
 			case "labelFont":
 				_, err = setLabelFont(path, values)
+			case "labelBackground":
+				_, err = setLabelBackground(path, values)
 			case "separators+":
 				_, err = addRoomSeparator(path, values)
 			case "pillars+":

--- a/CLI/controllers/interact_test.go
+++ b/CLI/controllers/interact_test.go
@@ -142,6 +142,13 @@ func TestLabelColorOk(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestLabelBackgroundOk(t *testing.T) {
+	controller, _, _ := interactLabelTestSetup(t)
+
+	err := controller.InteractObject("/Physical/BASIC/A/R1/A01", "labelBackground", "C0FFEE", false)
+	assert.Nil(t, err)
+}
+
 func TestContentOk(t *testing.T) {
 	controller, _, _ := interactLabelTestSetup(t)
 	err := controller.InteractObject("/Physical/BASIC/A/R1/A01", "content", true, false)


### PR DESCRIPTION
## Description

- Added functionality to make `labelBackground` send an **interact** command to the 3D client instead of a **modify** one

- Fixes #357 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test