### PR TITLE
feat(API) improved validation error messages

### DIFF
--- a/API/models/schemas/bldg_template_schema.json
+++ b/API/models/schemas/bldg_template_schema.json
@@ -5,7 +5,7 @@
     "properties": {
         "slug": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-]+$"
+            "$ref": "refs/types.json#/definitions/slug"
         },
         "category": {
             "type": "string",

--- a/API/models/schemas/building_schema.json
+++ b/API/models/schemas/building_schema.json
@@ -43,8 +43,8 @@
                 },
                 "rotation": {
                     "type": "string",
-                    "pattern": "^-?([0-9]*[.])?[0-9]+$"
-                  },
+                    "$ref": "refs/types.json#/definitions/float"
+                },
                 "template": {
                     "type": "string"
                 }

--- a/API/models/schemas/domain_schema.json
+++ b/API/models/schemas/domain_schema.json
@@ -17,7 +17,7 @@
       },
       "name": {
         "type": "string",
-        "pattern":"^\\w(\\w|\\-)*$"
+        "$ref": "refs/types.json#/definitions/name"
       },
       "attributes": {
         "type": "object",

--- a/API/models/schemas/obj_template_schema.json
+++ b/API/models/schemas/obj_template_schema.json
@@ -85,7 +85,8 @@
                         "$ref": "#/$defs/attributes"
                     },
                     "color": {
-                        "$ref": "#/$defs/color"
+                        "type": "string",
+                        "$ref": "refs/types.json#/definitions/colorTemplate"
                     },
                     "elemOrient": {
                         "type": "string",
@@ -129,7 +130,7 @@
         },
         "slug": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-]+$"
+            "$ref": "refs/types.json#/definitions/slug"
         },
         "slots": {
             "type": "array",
@@ -155,7 +156,8 @@
                         "$ref": "#/$defs/attributes"
                     },
                     "color": {
-                        "$ref": "#/$defs/color"
+                        "type": "string",
+                        "$ref": "refs/types.json#/definitions/colorTemplate"
                     },
                     
                     "elemPos": {
@@ -185,10 +187,6 @@
                     "type": "string"
                 }
             }
-        },
-        "color": {
-            "type": "string",
-            "pattern": "(^[0-9a-fA-F]{6}$)|(^@[a-zA-Z0-9-]+$)|(^$)"
         },
         "elemPos": {
             "type": "array",

--- a/API/models/schemas/refs/types.json
+++ b/API/models/schemas/refs/types.json
@@ -5,6 +5,10 @@
             "pattern": "^[0-9a-fA-F]{6}$",
             "description": "a 6 length hex value (e.g. 'C0FFEE')"
         },
+        "colorTemplate": {
+            "pattern": "(^[0-9a-fA-F]{6}$)|(^@[a-zA-Z0-9-]+$)|(^$)",
+            "description": "a 6 length hex value or '@[color name]' (e.g. 'C0FFEE', '@blue')"
+        },
         "metricImperialUnit": {
             "enum": ["mm", "cm", "m", "f"],
             "description": "'mm', 'cm', 'm' or 'f'"
@@ -14,20 +18,20 @@
             "description": "'mm', 'cm', 'm', 'f', 'U' or 'OU'"
         },
         "vector2": {
-            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
-            "description": "a vector2 (e.g. '{\"x\": 0.1, \"y\": 2.3}', '{\"x\": +.1, \"y\": -2}', '{\"x\": |3, \"y\": .4}')"
+            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
+            "description": "a vector2 (e.g. '{\"x\": 2.5, \"y\": 3}', '{\"x\": -3.5, \"y\": -3}')"
         },
         "vector3": {
-            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"z\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
-            "description": "a vector3 (e.g. '{\"x\": 0.1, \"y\": 2, \"z\": .3}', '{\"x\": |1, \"y\": +2, \"z\": -3}')"
+            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"z\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
+            "description": "a vector3 (e.g. '{\"x\": 2, \"y\": 2.5, \"z\": 3.33}', '{\"x\": 2, \"y\": -4, \"z\": -3.5}')"
         },
         "float": {
             "pattern": "^[-]?([0-9]*[.])?[0-9]+$",
-            "description": "a floating point number (e.g. '3.14', '1', '.2')"
+            "description": "a floating point number (e.g. '3.14', '-2.72', '1', '-2')"
         },
         "clearanceVector": {
             "pattern": "^\\[(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:,\\s*(?:\\d+(?:\\.\\d*)?|\\.\\d+)){5}\\]$",
-            "description": "six floating point numbers inside square brackets (e.g. '[0, .1, 0.2, 3, .4, 5.6]'"
+            "description": "six floating point numbers inside square brackets (e.g. '[2, 2.72, 3, 3.14, 4, 4.5]'"
         },
         "slug": {
             "pattern": "^[a-z0-9-_]+$",

--- a/API/models/schemas/refs/types.json
+++ b/API/models/schemas/refs/types.json
@@ -10,12 +10,10 @@
             "description": "a 6 length hex value or '@[color name]' (e.g. 'C0FFEE', '@blue')"
         },
         "metricImperialUnit": {
-            "enum": ["mm", "cm", "m", "f"],
-            "description": "'mm', 'cm', 'm' or 'f'"
+            "enum": ["mm", "cm", "m", "f"]
         },
         "metricImperialUUnit": {
-            "enum": ["mm", "cm", "m", "f", "U", "OU"],
-            "description": "'mm', 'cm', 'm', 'f', 'U' or 'OU'"
+            "enum": ["mm", "cm", "m", "f", "U", "OU"]
         },
         "vector2": {
             "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*((-|\\+)?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
@@ -35,15 +33,15 @@
         },
         "slug": {
             "pattern": "^[a-z0-9-_]+$",
-            "description": "a pattern with lowercase letters, numbers, '-' and '_' (e.g. 'abc_xyz-0')"
+            "description": "composed only of lowercase letters, numbers, '-' or '_' (e.g. 'abc_xyz-0')"
         },
         "name": {
             "pattern": "^\\w(\\w|\\-)*$",
-            "description": "a pattern with letters, numbers, '-' and '_' (e.g. 'ABC_xyz-0')"
+            "description": "composed only of letters, numbers, '-' or '_' (e.g. 'ABC_xyz-0')"
         },
         "id": {
             "pattern": "^\\w(\\w|\\-)*(\\.\\w(\\w|\\-)*)*$",
-            "description": "a pattern with letters, numbers, '-', '_' and '.' (e.g. 'BASIC.abc_xyz-0')"
+            "description": "composed only of letters, numbers, '-', '_' or '.' (e.g. 'BASIC.abc_xyz-0')"
         }
     }
 }

--- a/API/models/schemas/refs/types.json
+++ b/API/models/schemas/refs/types.json
@@ -2,34 +2,44 @@
     "$id": "refs/types.json",
     "definitions": {
         "color": {
-            "pattern": "^[0-9a-fA-F]{6}$"
+            "pattern": "^[0-9a-fA-F]{6}$",
+            "description": "a 6 length hex value (e.g. 'C0FFEE')"
         },
         "metricImperialUnit": {
-            "enum": ["mm", "cm", "m", "f"]
+            "enum": ["mm", "cm", "m", "f"],
+            "description": "'mm', 'cm', 'm' or 'f'"
         },
         "metricImperialUUnit": {
-            "enum": ["mm", "cm", "m", "f", "U", "OU"]
+            "enum": ["mm", "cm", "m", "f", "U", "OU"],
+            "description": "'mm', 'cm', 'm', 'f', 'U' or 'OU'"
         },
         "vector2": {
-            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*}\\s*$"
+            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
+            "description": "a vector2 (e.g. '{\"x\": 0.1, \"y\": 2.3}', '{\"x\": +.1, \"y\": -2}', '{\"x\": |3, \"y\": .4}')"
         },
         "vector3": {
-            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"z\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*}\\s*$"
+            "pattern": "^\\s*{\\s*\"x\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"y\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*,\\s*\"z\"\\s*:\\s*([-|+]?[0-9]*[.]?)?[0-9]+\\s*}\\s*$",
+            "description": "a vector3 (e.g. '{\"x\": 0.1, \"y\": 2, \"z\": .3}', '{\"x\": |1, \"y\": +2, \"z\": -3}')"
         },
         "float": {
-            "pattern": "^[-]?([0-9]*[.])?[0-9]+$"
+            "pattern": "^[-]?([0-9]*[.])?[0-9]+$",
+            "description": "a floating point number (e.g. '3.14', '1', '.2')"
         },
         "clearanceVector": {
-            "pattern": "^\\[(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:,\\s*(?:\\d+(?:\\.\\d*)?|\\.\\d+)){5}\\]$"
+            "pattern": "^\\[(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:,\\s*(?:\\d+(?:\\.\\d*)?|\\.\\d+)){5}\\]$",
+            "description": "six floating point numbers inside square brackets (e.g. '[0, .1, 0.2, 3, .4, 5.6]'"
         },
         "slug": {
-            "pattern": "^[a-z0-9-_]+$"
+            "pattern": "^[a-z0-9-_]+$",
+            "description": "a pattern with lowercase letters, numbers, '-' and '_' (e.g. 'abc_xyz-0')"
         },
         "name": {
-            "pattern": "^\\w(\\w|\\-)*$"
+            "pattern": "^\\w(\\w|\\-)*$",
+            "description": "a pattern with letters, numbers, '-' and '_' (e.g. 'ABC_xyz-0')"
         },
         "id": {
-            "pattern": "^\\w(\\w|\\-)*(\\.\\w(\\w|\\-)*)*$"
+            "pattern": "^\\w(\\w|\\-)*(\\.\\w(\\w|\\-)*)*$",
+            "description": "a pattern with letters, numbers, '-', '_' and '.' (e.g. 'BASIC.abc_xyz-0')"
         }
     }
 }

--- a/API/models/schemas/room_schema.json
+++ b/API/models/schemas/room_schema.json
@@ -30,7 +30,7 @@
         },
         "rotation": {
           "type": "string",
-          "pattern": "^-?([0-9]*[.])?[0-9]+$"
+          "$ref": "refs/types.json#/definitions/float"
         },
         "posXY": {
           "type": "string",

--- a/API/models/schemas/room_template_schema.json
+++ b/API/models/schemas/room_template_schema.json
@@ -160,7 +160,7 @@
         },
         "slug": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9-]+$"
+            "$ref": "refs/types.json#/definitions/slug"
         },
         "technicalArea": {
             "type": "array",
@@ -187,7 +187,7 @@
                 "properties": {
                     "color": {
                         "type": "string",
-                        "pattern": "(^[0-9a-fA-F]{6}$)|(^@[a-zA-Z0-9-]+$)|(^$)"
+                        "$ref": "refs/types.json#/definitions/colorTemplate"
                     },
                     "label": {
                         "type": "string"

--- a/API/models/schemas/site_schema.json
+++ b/API/models/schemas/site_schema.json
@@ -17,7 +17,7 @@
     },
     "name": {
       "type": "string",
-      "pattern":"^\\w(\\w|\\-)*$"
+      "$ref": "refs/types.json#/definitions/name"
     },
     "tags": {
       "type": "array",

--- a/API/models/schemas/test_data/KO/obj_template4.json
+++ b/API/models/schemas/test_data/KO/obj_template4.json
@@ -1,5 +1,5 @@
 {
-    "slug"        : "ERROR-example-123",
+    "slug"        : "error_example-123",
     "description" : "NeXtScale ns1200",
     "category"    : "device",
     "sizeWDHmm"   : [447, 914.5, 263.3],

--- a/API/models/validateEntity_test.go
+++ b/API/models/validateEntity_test.go
@@ -61,14 +61,14 @@ func TestValidateJsonSchema(t *testing.T) {
 func TestErrorValidateJsonSchema(t *testing.T) {
 	// Test test_data/KO json files
 	expectedErrors := map[string][]string{
-		"site1":     {"missing properties: 'domain'", "/attributes/reservedColor does not match pattern"},
+		"site1":     {"missing properties: 'domain'", "/attributes/reservedColor should be"},
 		"building1": {"missing properties: 'posXYUnit'", "/attributes/height expected string, but got number"},
 		"room1":     {"additionalProperties 'banana' not allowed", "/attributes/axisOrientation value must be one of"},
-		"rack1":     {"/attributes/posXYZ does not match pattern", "/attributes/heightUnit value must be one of"},
+		"rack1":     {"/attributes/posXYZ should be", "/attributes/heightUnit value must be one of"},
 		"device1":   {"missing properties: 'template'", "/description expected array, but got string"},
-		"group1":    {"/attributes missing properties: 'content'", "/name does not match pattern"},
+		"group1":    {"/attributes missing properties: 'content'", "/name should be"},
 		"obj_template5": {
-			"/slug does not match pattern",
+			"/slug should be",
 			"/attributes/vendor expected string, but got number",
 			"/slots/0/elemOrient value must be one of ",
 			"/slots/1/elemPos maximum 3 items required, but found 4 items",
@@ -76,12 +76,12 @@ func TestErrorValidateJsonSchema(t *testing.T) {
 			"/slots/1/elemOrient value must be one of",
 			"/slots/2 missing properties: 'elemOrient'",
 			"/slots/2/labelPos value must be one of ",
-			"/slots/3/color does not match pattern",
+			"/slots/3/color should be",
 		},
 		"obj_template4": {
 			"/components/0/elemPos minimum 3 items required, but found 0 items",
 			`/components/1/elemOrient value must be one of "horizontal", "vertical", ""`,
-			"/components/1/color does not match pattern",
+			"/components/1/color should be",
 			"/components/3/labelPos value must be one of",
 			"/slots/0/elemOrient value must be one of",
 		},


### PR DESCRIPTION
## Description

- Added a description for each `definition` of type, such as `slug` and `vector2`

- Modified some schemas to reference `types.json`

- Added logic to substitute the regex pattern in validation error messages for the friendlier description

- Updated unit tests for the validation

- Fixes #291 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test