### PR TITLE
Endpoint for event notifications + APP fixes

### DIFF
--- a/.github/actions/build/APP/action.yaml
+++ b/.github/actions/build/APP/action.yaml
@@ -15,7 +15,7 @@ runs:
       - uses: actions/checkout@v3.2.0
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.6'
+          flutter-version: '3.16.9'
           channel: 'stable'
           
       - name: Set up

--- a/.github/actions/build/multi-platform/action.yaml
+++ b/.github/actions/build/multi-platform/action.yaml
@@ -71,7 +71,8 @@ runs:
       uses: ./.github/actions/build/docker
       with:
         IMAGE_NAME: "ogree-app"
-        FOLDER_NAME: "./APP"
+        FOLDER_NAME: "."
+        DOCKERFILE: "APP/Dockerfile"
         VERSION: ${{ env.VERSION }}
         TEAM_DOCKER_URL: ${{ inputs.TEAM_DOCKER_URL }}
         TEAM_USERNAME: ${{ inputs.TEAM_USERNAME }}

--- a/.github/actions/build/windows/action.yaml
+++ b/.github/actions/build/windows/action.yaml
@@ -11,7 +11,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.13.6'
+        flutter-version: '3.16.9'
         channel: 'stable'
 
     - name: Windows flutter build

--- a/.github/workflows/app-unit-test.yml
+++ b/.github/workflows/app-unit-test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.13.6'
+          flutter-version: '3.16.9'
           channel: 'stable'
           
       - name: Set up 

--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -1043,6 +1043,12 @@ func UpdateEntity(w http.ResponseWriter, r *http.Request) {
 		} else {
 			u.Respond(w, u.RespDataWrapper("successfully updated "+entity, data))
 			println("send to eventnotifier")
+			if entity == "tag" || entity == "layer" {
+				data = map[string]any{
+					"old-slug": id,
+					entity:     data,
+				}
+			}
 			eventNotifier <- u.FormatNotifyData("modify", entity, data)
 			println("sent")
 		}

--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -177,6 +177,11 @@ func CreateEntity(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.WriteHeader(http.StatusCreated)
 		u.Respond(w, u.RespDataWrapper("successfully created "+entStr, resp))
+		if entInt == u.LAYER {
+			println("send to eventnotifier")
+			eventNotifier <- u.FormatNotifyData("create", entStr, resp)
+			println("sent")
+		}
 	}
 }
 
@@ -494,6 +499,9 @@ func HandleGenericObjects(w http.ResponseWriter, r *http.Request) {
 				u.RespondWithError(w, modelErr)
 				return
 			}
+			println("send to eventnotifier")
+			eventNotifier <- u.FormatNotifyData("delete", entStr, objStr)
+			println("sent")
 		}
 		u.Respond(w, u.RespDataWrapper("successfully deleted objects", matchingObjects))
 	} else if r.Method == "OPTIONS" {
@@ -895,6 +903,9 @@ func DeleteEntity(w http.ResponseWriter, r *http.Request) {
 		} else {
 			w.WriteHeader(http.StatusNoContent)
 			u.Respond(w, u.Message("successfully deleted"))
+			println("send to eventnotifier")
+			eventNotifier <- u.FormatNotifyData("delete", entityStr, id)
+			println("sent")
 		}
 	}
 }
@@ -1031,6 +1042,9 @@ func UpdateEntity(w http.ResponseWriter, r *http.Request) {
 			u.RespondWithError(w, modelErr)
 		} else {
 			u.Respond(w, u.RespDataWrapper("successfully updated "+entity, data))
+			println("send to eventnotifier")
+			eventNotifier <- u.FormatNotifyData("modify", entity, data)
+			println("sent")
 		}
 	}
 }

--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -178,9 +178,7 @@ func CreateEntity(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		u.Respond(w, u.RespDataWrapper("successfully created "+entStr, resp))
 		if entInt == u.LAYER {
-			println("send to eventnotifier")
 			eventNotifier <- u.FormatNotifyData("create", entStr, resp)
-			println("sent")
 		}
 	}
 }
@@ -499,9 +497,7 @@ func HandleGenericObjects(w http.ResponseWriter, r *http.Request) {
 				u.RespondWithError(w, modelErr)
 				return
 			}
-			println("send to eventnotifier")
 			eventNotifier <- u.FormatNotifyData("delete", entStr, objStr)
-			println("sent")
 		}
 		u.Respond(w, u.RespDataWrapper("successfully deleted objects", matchingObjects))
 	} else if r.Method == "OPTIONS" {
@@ -903,9 +899,7 @@ func DeleteEntity(w http.ResponseWriter, r *http.Request) {
 		} else {
 			w.WriteHeader(http.StatusNoContent)
 			u.Respond(w, u.Message("successfully deleted"))
-			println("send to eventnotifier")
 			eventNotifier <- u.FormatNotifyData("delete", entityStr, id)
-			println("sent")
 		}
 	}
 }
@@ -1042,7 +1036,6 @@ func UpdateEntity(w http.ResponseWriter, r *http.Request) {
 			u.RespondWithError(w, modelErr)
 		} else {
 			u.Respond(w, u.RespDataWrapper("successfully updated "+entity, data))
-			println("send to eventnotifier")
 			if entity == "tag" || entity == "layer" {
 				data = map[string]any{
 					"old-slug": id,
@@ -1050,7 +1043,6 @@ func UpdateEntity(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			eventNotifier <- u.FormatNotifyData("modify", entity, data)
-			println("sent")
 		}
 	}
 }

--- a/API/controllers/event.go
+++ b/API/controllers/event.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func CreateEventStream(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Type")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Simulate sending events (you can replace this with real data)
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(w, "data: %s\n\n", fmt.Sprintf("Event %d", i))
+		time.Sleep(3 * time.Second)
+		w.(http.Flusher).Flush()
+	}
+
+	// Simulate closing the connection
+	fmt.Fprintf(w, "event: close")
+	w.(http.Flusher).Flush()
+}

--- a/API/controllers/event.go
+++ b/API/controllers/event.go
@@ -11,49 +11,45 @@ var eventNotifier chan string
 var broadcaster u.BroadcastServer
 
 func init() {
+	// Create channel to send events to broadcaster
 	ctx, _ := context.WithCancel(context.Background())
 	eventNotifier = make(chan string)
 	broadcaster = u.NewBroadcastServer(ctx, eventNotifier)
 }
 
+// swagger:operation GET /api/events Events CreateEventStream
+// Get real-time notifications (SSE stream)
+// Opens a SSE stream with the caller where the API will send a new event (message in JSON format)
+// every time a modify or delete of any object succeeds. Also applies to create layer.
+// ---
+// security:
+// - bearer: []
+// produces:
+// - text/event-stream
+//
+// responses:
+//		'200':
+//			description: 'Successfully established stream, keep it open.'
+
 func CreateEventStream(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("******************************************************")
 	fmt.Println("FUNCTION CALL: 	 CreateEventStream ")
 	fmt.Println("******************************************************")
+	// Configure SSE stream
 	w.Header().Set("Access-Control-Expose-Headers", "Content-Type")
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	// Simulate sending events (you can replace this with real data)
-	// for i := 0; i < 1; i++ {
-	// 	fmt.Fprintf(w, "data: %s\n\n", fmt.Sprintf("Event %d", i))
-	// 	time.Sleep(3 * time.Second)
-	// 	w.(http.Flusher).Flush()
-	// }
-
-	// done := make(chan bool)
-
-	// go func() {
-	// 	if msg, ok := <-output; ok {
-	// 		c.SSEvent("msg", string(msg))
-	// 		return true
-	// 	}
-	// 	return false
-	// 	done <- true
-	// }()
+	// Subscribe to broadcaster to receive events from entity controller
 	listener := broadcaster.Subscribe()
 	for str := range listener {
-		println("GOT IT")
-		fmt.Println(str)
+		// New event receive, send it
 		fmt.Fprintf(w, "data: %v\n", str)
 		w.(http.Flusher).Flush()
 	}
 
-	// <-done
-
-	println("##END")
-	// Simulate closing the connection
+	// Close the connection if not listening anymore
 	fmt.Fprintf(w, "event: close")
 	w.(http.Flusher).Flush()
 }

--- a/API/controllers/event.go
+++ b/API/controllers/event.go
@@ -1,15 +1,20 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	u "p3/utils"
 	"time"
 )
 
 var eventNotifier chan string
+var broadcaster u.BroadcastServer
 
 func init() {
+	ctx, _ := context.WithCancel(context.Background())
 	eventNotifier = make(chan string)
+	broadcaster = u.NewBroadcastServer(ctx, eventNotifier)
 }
 
 func CreateEventStream(w http.ResponseWriter, r *http.Request) {
@@ -38,7 +43,8 @@ func CreateEventStream(w http.ResponseWriter, r *http.Request) {
 	// 	return false
 	// 	done <- true
 	// }()
-	for str := range eventNotifier {
+	listener := broadcaster.Subscribe()
+	for str := range listener {
 		println("GOT IT")
 		fmt.Println(str)
 		fmt.Fprintf(w, "data: %v\n", str)

--- a/API/controllers/event.go
+++ b/API/controllers/event.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	u "p3/utils"
-	"time"
 )
 
 var eventNotifier chan string
@@ -27,11 +26,11 @@ func CreateEventStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 
 	// Simulate sending events (you can replace this with real data)
-	for i := 0; i < 1; i++ {
-		fmt.Fprintf(w, "data: %s\n\n", fmt.Sprintf("Event %d", i))
-		time.Sleep(3 * time.Second)
-		w.(http.Flusher).Flush()
-	}
+	// for i := 0; i < 1; i++ {
+	// 	fmt.Fprintf(w, "data: %s\n\n", fmt.Sprintf("Event %d", i))
+	// 	time.Sleep(3 * time.Second)
+	// 	w.(http.Flusher).Flush()
+	// }
 
 	// done := make(chan bool)
 

--- a/API/controllers/event.go
+++ b/API/controllers/event.go
@@ -6,19 +6,48 @@ import (
 	"time"
 )
 
+var eventNotifier chan string
+
+func init() {
+	eventNotifier = make(chan string)
+}
+
 func CreateEventStream(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("******************************************************")
+	fmt.Println("FUNCTION CALL: 	 CreateEventStream ")
+	fmt.Println("******************************************************")
 	w.Header().Set("Access-Control-Expose-Headers", "Content-Type")
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
 	// Simulate sending events (you can replace this with real data)
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1; i++ {
 		fmt.Fprintf(w, "data: %s\n\n", fmt.Sprintf("Event %d", i))
 		time.Sleep(3 * time.Second)
 		w.(http.Flusher).Flush()
 	}
 
+	// done := make(chan bool)
+
+	// go func() {
+	// 	if msg, ok := <-output; ok {
+	// 		c.SSEvent("msg", string(msg))
+	// 		return true
+	// 	}
+	// 	return false
+	// 	done <- true
+	// }()
+	for str := range eventNotifier {
+		println("GOT IT")
+		fmt.Println(str)
+		fmt.Fprintf(w, "data: %v\n", str)
+		w.(http.Flusher).Flush()
+	}
+
+	// <-done
+
+	println("##END")
 	// Simulate closing the connection
 	fmt.Fprintf(w, "event: close")
 	w.(http.Flusher).Flush()

--- a/API/router/router.go
+++ b/API/router/router.go
@@ -33,6 +33,9 @@ func Router(jwt func(next http.Handler) http.Handler) *mux.Router {
 	router.HandleFunc("/api/version",
 		controllers.GetVersion).Methods("GET", "OPTIONS", "HEAD")
 
+	router.HandleFunc("/api/events",
+		controllers.CreateEventStream).Methods("GET", "OPTIONS", "HEAD")
+
 	// User and Authentication
 	router.HandleFunc("/api/login",
 		controllers.Authenticate).Methods("POST", "OPTIONS")

--- a/API/swagger.json
+++ b/API/swagger.json
@@ -58,6 +58,28 @@
         }
       }
     },
+    "/api/events": {
+      "get": {
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "description": "Get real-time notifications (SSE stream)\nOpens a SSE stream with the caller where the API will send a new event (message in JSON format)\nevery time a modify or delete of any object succeeds. Also applies to create layer.",
+        "produces": [
+          "text/event-stream"
+        ],
+        "tags": [
+          "Events"
+        ],
+        "operationId": "CreateEventStream",
+        "responses": {
+          "200": {
+            "description": "Successfully established stream, keep it open."
+          }
+        }
+      }
+    },
     "/api/hierarchy": {
       "get": {
         "security": [

--- a/API/utils/broadcast.go
+++ b/API/utils/broadcast.go
@@ -2,6 +2,10 @@ package utils
 
 import "context"
 
+// BroadcastServer attaches to a channel and notify all listeners
+// every time new data arrives from the channel
+// Used for the SSE stream
+
 type BroadcastServer interface {
 	Subscribe() <-chan string
 	CancelSubscription(<-chan string)
@@ -69,7 +73,6 @@ func (s *broadcastServer) serve(ctx context.Context) {
 					case <-ctx.Done():
 						return
 					}
-
 				}
 			}
 		}

--- a/API/utils/broadcast.go
+++ b/API/utils/broadcast.go
@@ -1,0 +1,77 @@
+package utils
+
+import "context"
+
+type BroadcastServer interface {
+	Subscribe() <-chan string
+	CancelSubscription(<-chan string)
+}
+type broadcastServer struct {
+	source         <-chan string
+	listeners      []chan string
+	addListener    chan chan string
+	removeListener chan (<-chan string)
+}
+
+func (s *broadcastServer) Subscribe() <-chan string {
+	newListener := make(chan string)
+	s.addListener <- newListener
+	return newListener
+}
+
+func (s *broadcastServer) CancelSubscription(channel <-chan string) {
+	s.removeListener <- channel
+}
+
+func NewBroadcastServer(ctx context.Context, source <-chan string) BroadcastServer {
+	service := &broadcastServer{
+		source:         source,
+		listeners:      make([]chan string, 0),
+		addListener:    make(chan chan string),
+		removeListener: make(chan (<-chan string)),
+	}
+	go service.serve(ctx)
+	return service
+}
+
+func (s *broadcastServer) serve(ctx context.Context) {
+	defer func() {
+		for _, listener := range s.listeners {
+			if listener != nil {
+				close(listener)
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case newListener := <-s.addListener:
+			s.listeners = append(s.listeners, newListener)
+		case listenerToRemove := <-s.removeListener:
+			for i, ch := range s.listeners {
+				if ch == listenerToRemove {
+					s.listeners[i] = s.listeners[len(s.listeners)-1]
+					s.listeners = s.listeners[:len(s.listeners)-1]
+					close(ch)
+					break
+				}
+			}
+		case val, ok := <-s.source:
+			if !ok {
+				return
+			}
+			for _, listener := range s.listeners {
+				if listener != nil {
+					select {
+					case listener <- val:
+					case <-ctx.Done():
+						return
+					}
+
+				}
+			}
+		}
+	}
+}

--- a/API/utils/util.go
+++ b/API/utils/util.go
@@ -4,6 +4,7 @@ package utils
 //returns json response
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log"
@@ -455,6 +456,22 @@ func GetParentOfEntityByInt(entity int) int {
 	default:
 		return entity - 1
 	}
+}
+
+func FormatNotifyData(msgType, entityStr string, data any) string {
+	if entityStr == "tag" {
+		msgType = msgType + "-tag"
+	} else if entityStr == "layer" {
+		msgType = msgType + "-layer"
+	}
+	//convert to json then string
+	buff := bytes.NewBuffer([]byte{})
+	encoder := json.NewEncoder(buff)
+	err := encoder.Encode(map[string]any{"type": msgType, "data": data})
+	if err != nil {
+		println("Error notifying 3D client: unable to encode json data")
+	}
+	return buff.String()
 }
 
 // Helper functions

--- a/APP/Dockerfile
+++ b/APP/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y curl git wget unzip libgconf-2-4 gdb libstdc++6 libglu1-m
 RUN apt-get clean
 
 # Download Flutter SDK from Github repo
-RUN git clone --depth 1 --branch 3.13.6 https://github.com/flutter/flutter.git /usr/local/flutter
+RUN git clone --depth 1 --branch 3.16.9 https://github.com/flutter/flutter.git /usr/local/flutter
 
 # Set flutter environment path
 ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PATH}"
@@ -19,7 +19,8 @@ ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:${PAT
 RUN flutter doctor
 
 # Copy files to container and build
-COPY . /app/
+COPY APP/ /app/
+COPY API/models/schemas/ /API/models/schemas/
 WORKDIR /app/
 RUN flutter pub get
 RUN flutter build web 

--- a/APP/README.md
+++ b/APP/README.md
@@ -25,7 +25,7 @@ Our dockerfile is multi-stage: the first image install flutter and its dependenc
 
 From the root of OGrEE-Core, run the following to build the Docker image:
 ```console
-OGrEE-Core$ docker build APP -t ogree-app
+OGrEE-Core$ docker build . -f APP/Dockerfile -t ogree-app
 ```
 
 To run a container with the built image and expose the app in the local port 8080:

--- a/APP/lib/common/api_backend.dart
+++ b/APP/lib/common/api_backend.dart
@@ -60,7 +60,7 @@ String wrapResponseMsg(http.Response response, {String? message}) {
 
 // API calls
 Future<Result<List<String>, Exception>> loginAPI(String email, String password,
-    {String userUrl = ""}) async {
+    {String userUrl = "", bool stayLoggedIn = false}) async {
   // Make sure it is clean
   tenantUrl = "";
   isTenantAdmin = false;
@@ -77,8 +77,11 @@ Future<Result<List<String>, Exception>> loginAPI(String email, String password,
   try {
     Uri url = Uri.parse('$apiUrl/api/login');
     final response = await http.post(url,
-        body: json
-            .encode(<String, String>{'email': email, 'password': password}));
+        body: json.encode(<String, dynamic>{
+          'email': email,
+          'password': password,
+          'stayLoggedIn': stayLoggedIn
+        }));
 
     // Handle response
     Map<String, dynamic> data = json.decode(response.body);

--- a/APP/lib/pages/projects_page.dart
+++ b/APP/lib/pages/projects_page.dart
@@ -91,17 +91,7 @@ class _ProjectsPageState extends State<ProjectsPage> {
                 builder: (context, _) {
                   if (!_gotData) {
                     return const Center(child: CircularProgressIndicator());
-                  } else if (_projects != null && _projects!.isNotEmpty) {
-                    return Expanded(
-                      child: SingleChildScrollView(
-                        child: Wrap(
-                          spacing: 5,
-                          children: getCards(context),
-                        ),
-                      ),
-                    );
-                  } else if ((_tenants != null && _tenants!.isNotEmpty) ||
-                      (_tools != null && _tools!.isNotEmpty)) {
+                  } else if (!widget.isTenantMode) {
                     return Expanded(
                       child: SingleChildScrollView(
                         child: Wrap(
@@ -111,8 +101,20 @@ class _ProjectsPageState extends State<ProjectsPage> {
                       ),
                     );
                   } else {
-                    // Empty messages
-                    return Text(localeMsg.noProjects);
+                    if ((_tenants != null && _tenants!.isNotEmpty) ||
+                        (_tools != null && _tools!.isNotEmpty)) {
+                      return Expanded(
+                        child: SingleChildScrollView(
+                          child: Wrap(
+                            spacing: 5,
+                            children: getCards(context),
+                          ),
+                        ),
+                      );
+                    } else {
+                      // Empty messages
+                      return Text(localeMsg.noProjects);
+                    }
                   }
                 }),
           ],

--- a/APP/lib/widgets/login_card.dart
+++ b/APP/lib/widgets/login_card.dart
@@ -165,11 +165,15 @@ class _LoginCardState extends State<LoginCard> {
                                     SizedBox(
                                       height: 24,
                                       width: 24,
-                                      child: Checkbox(
-                                        value: _isChecked,
-                                        onChanged: (bool? value) =>
-                                            setState(() => _isChecked = value!),
-                                      ),
+                                      child: StatefulBuilder(
+                                          builder: (context, localSetState) {
+                                        return Checkbox(
+                                          value: _isChecked,
+                                          onChanged: (bool? value) =>
+                                              localSetState(
+                                                  () => _isChecked = value!),
+                                        );
+                                      }),
                                     ),
                                     const SizedBox(width: 8),
                                     Text(
@@ -332,9 +336,9 @@ class BackendInput extends StatelessWidget {
               isDense: true,
               labelText: localeMsg.selectServer,
               labelStyle: const TextStyle(fontSize: 14)),
-          onTap: () {
-            textEditingController.clear();
-          },
+          // onTap: () {
+          //   textEditingController.clear();
+          // },
         );
       },
       optionsViewBuilder: (BuildContext context,

--- a/APP/lib/widgets/login_card.dart
+++ b/APP/lib/widgets/login_card.dart
@@ -337,9 +337,6 @@ class BackendInput extends StatelessWidget {
               isDense: true,
               labelText: localeMsg.selectServer,
               labelStyle: const TextStyle(fontSize: 14)),
-          // onTap: () {
-          //   textEditingController.clear();
-          // },
         );
       },
       optionsViewBuilder: (BuildContext context,

--- a/APP/lib/widgets/login_card.dart
+++ b/APP/lib/widgets/login_card.dart
@@ -17,7 +17,7 @@ class LoginCard extends StatefulWidget {
 
 class _LoginCardState extends State<LoginCard> {
   final _formKey = GlobalKey<FormState>();
-  bool _isChecked = false;
+  bool _stayLoggedIn = false;
   String? _email;
   String? _password;
   String _apiUrl = "";
@@ -168,10 +168,10 @@ class _LoginCardState extends State<LoginCard> {
                                       child: StatefulBuilder(
                                           builder: (context, localSetState) {
                                         return Checkbox(
-                                          value: _isChecked,
+                                          value: _stayLoggedIn,
                                           onChanged: (bool? value) =>
                                               localSetState(
-                                                  () => _isChecked = value!),
+                                                  () => _stayLoggedIn = value!),
                                         );
                                       }),
                                     ),
@@ -249,7 +249,8 @@ class _LoginCardState extends State<LoginCard> {
   tryLogin(AppLocalizations localeMsg, ScaffoldMessengerState messenger) async {
     if (_formKey.currentState!.validate()) {
       _formKey.currentState!.save();
-      final result = await loginAPI(_email!, _password!, userUrl: _apiUrl);
+      final result = await loginAPI(_email!, _password!,
+          userUrl: _apiUrl, stayLoggedIn: _stayLoggedIn);
       switch (result) {
         case Success(value: final loginData):
           if (apiType == BackendType.tenant) {

--- a/APP/lib/widgets/select_objects/select_objects.dart
+++ b/APP/lib/widgets/select_objects/select_objects.dart
@@ -48,21 +48,31 @@ class _SelectObjectsState extends State<SelectObjects> {
               child: Card(
                 margin: const EdgeInsets.all(0.1),
                 child: appController.treeController.roots.isEmpty
-                    ? Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            Icons.warning_rounded,
-                            size: 50,
-                            color: Colors.grey.shade600,
+                    ? Stack(children: [
+                        Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.warning_rounded,
+                                size: 50,
+                                color: Colors.grey.shade600,
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.only(top: 16),
+                                child: Text(
+                                    "${AppLocalizations.of(context)!.noObjectsFound} :("),
+                              ),
+                            ],
                           ),
-                          Padding(
-                            padding: const EdgeInsets.only(top: 16),
-                            child: Text(
-                                "${AppLocalizations.of(context)!.noObjectsFound} :("),
-                          ),
-                        ],
-                      )
+                        ),
+                        addObjectButton(
+                            context,
+                            widget.namespace,
+                            () => setState(() {
+                                  widget.load = true;
+                                })),
+                      ])
                     : _ResponsiveBody(
                         namespace: widget.namespace,
                         noFilters: widget.namespace != Namespace.Physical,
@@ -153,38 +163,42 @@ class _ResponsiveBody extends StatelessWidget {
                       SettingsView(isTenantMode: false, noFilters: noFilters)),
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 6, bottom: 6),
-            child: Align(
-              alignment: Alignment.bottomLeft,
-              child: SizedBox(
-                height: 34,
-                width: 34,
-                child: IconButton(
-                  padding: EdgeInsets.all(0.0),
-                  iconSize: 24,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.blue.shade600,
-                    foregroundColor: Colors.white,
-                  ),
-                  onPressed: () => showCustomPopup(
-                      context,
-                      namespace == Namespace.Organisational
-                          ? DomainPopup(
-                              parentCallback: callback,
-                            )
-                          : ObjectPopup(
-                              parentCallback: callback, namespace: namespace),
-                      isDismissible: true),
-                  icon: const Icon(Icons.add),
-                ),
-              ),
-            ),
-          ),
+          addObjectButton(context, namespace, callback),
         ],
       ),
     );
   }
+}
+
+addObjectButton(
+    BuildContext context, Namespace namespace, Function() callback) {
+  return Padding(
+    padding: const EdgeInsets.only(left: 6, bottom: 6),
+    child: Align(
+      alignment: Alignment.bottomLeft,
+      child: SizedBox(
+        height: 34,
+        width: 34,
+        child: IconButton(
+          padding: EdgeInsets.all(0.0),
+          iconSize: 24,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue.shade600,
+            foregroundColor: Colors.white,
+          ),
+          onPressed: () => showCustomPopup(
+              context,
+              namespace == Namespace.Organisational
+                  ? DomainPopup(
+                      parentCallback: callback,
+                    )
+                  : ObjectPopup(parentCallback: callback, namespace: namespace),
+              isDismissible: true),
+          icon: const Icon(Icons.add),
+        ),
+      ),
+    ),
+  );
 }
 
 class SettingsViewPopup extends StatelessWidget {

--- a/APP/macos/Podfile.lock
+++ b/APP/macos/Podfile.lock
@@ -21,9 +21,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
 
 PODFILE CHECKSUM: eec3430f260cde219af51c43f1bcfccf35ab54d0
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/APP/pubspec.lock
+++ b/APP/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: eb376e9acf6938204f90eb3b1f00b578640d3188b4c8a8ec054f9f479af8d051
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "64.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "69f54f967773f6c26c7dcb13e93d7ccee8b17a641689da39e878d5cf13b06893"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.2.0"
   args:
     dependency: transitive
     description:
@@ -61,18 +61,18 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "64e12b0521812d1684b1917bc80945625391cb9bdd4312536b1d69dcb6133ed8"
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: c9e32d21dd6626b5c163d48b037ce906bbe428bc23ab77bcd77bb21e593b6185
+      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.11"
+    version: "7.3.0"
   built_collection:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: a8de5955205b4d1dbbbc267daddf2178bd737e4bab8987c04a500478c9651e74
+      sha256: a3ec2e0f967bc47f69f95009bb93db936288d61d5343b9436e378b28a2f830c6
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.3"
+    version: "8.9.0"
   characters:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.10.0"
   collection:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.4"
   fake_async:
     dependency: transitive
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: be325344c1f3070354a1d84a231a1ba75ea85d413774ec4bdf444c023342e030
+      sha256: "4e42aacde3b993c5947467ab640882c56947d9d27342a5b6f2895b23956954a6"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "6.1.1"
   fixnum:
     dependency: transitive
     description:
@@ -282,10 +282,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "3.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -295,10 +295,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: f185ac890306b5779ecbd611f52502d8d4d63d27703ef73161ca0407e815f02c
+      sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.17"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -329,10 +329,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: e20ff62b158b96f392bfc8afe29dee1503c94fbea2cbe8186fd59b756b8ae982
+      sha256: f0b8d115a13ecf827013ec9fc883390ccc0e87a96ed5347a3114cac177ef18e8
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "6.1.0"
   graphs:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -393,10 +393,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "4186c61b32f99e60f011f7160e32c89a758ae9b1d0c6d28e2c02ef0382300e2b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.0"
   json_annotation:
     dependency: transitive
     description:
@@ -409,10 +409,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   logging:
     dependency: transitive
     description:
@@ -449,10 +449,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   mockito:
     dependency: "direct dev"
     description:
@@ -489,18 +489,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6b8b19bd80da4f11ce91b2d1fb931f3006911477cec227cce23d3253d80df3f1"
+      sha256: "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d"
+      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -513,10 +513,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
@@ -529,18 +529,18 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
+      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -590,10 +590,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_span:
     dependency: transitive
     description:
@@ -638,26 +638,26 @@ packages:
     dependency: transitive
     description:
       name: syncfusion_flutter_core
-      sha256: "9f0a4593f7642b2f106e329734d0e5fc746baf8d0a59495eec586cd0d9ba7d02"
+      sha256: c0693d88cbdef2af5da286c605e5e8f33216c8f6cb3bc92a88a51decfb62bace
       url: "https://pub.dev"
     source: hosted
-    version: "22.2.12"
+    version: "24.2.3"
   syncfusion_flutter_datepicker:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datepicker
-      sha256: c09d8a84f07da41c12b02ac350f4aab8b73be2c51095fca9f9404b2a5af67585
+      sha256: "8ed5aa0217fafe1788d815766d98ece641d1cf067b47ca3d71da81e7605b0d5c"
       url: "https://pub.dev"
     source: hosted
-    version: "22.2.12"
+    version: "24.2.3"
   syncfusion_localizations:
     dependency: "direct main"
     description:
       name: syncfusion_localizations
-      sha256: cbed6be76a708beabf380a2b98843ee636bb5f660596ec5ab8ffccc9f859b3cc
+      sha256: "4454a3768eaae9d5d243ffeafebec5de38b0dfadfb01d6b49638417687a82817"
       url: "https://pub.dev"
     source: hosted
-    version: "22.2.12"
+    version: "24.2.3"
   term_glyph:
     dependency: transitive
     description:
@@ -718,26 +718,26 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "31222ffb0063171b526d3e569079cf1f8b294075ba323443fdc690842bfd4def"
+      sha256: "507dc655b1d9cb5ebc756032eb785f114e415f91557b73bf60b7e201dfedeb2f"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.2"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "4ac97281cf60e2e8c5cc703b2b28528f9b50c8f7cebc71df6bdf0845f647268a"
+      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.4"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "9f2d390e096fdbe1e6e6256f97851e51afc2d9c423d3432f1d6a02a8a9a8b9fd"
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   url_launcher_macos:
     dependency: transitive
     description:
@@ -750,26 +750,26 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: "980e8d9af422f477be6948bdfb68df8433be71f5743a188968b0c1b887807e50"
+      sha256: a932c3a8082e118f80a475ce692fde89dc20fddb24c57360b96bc56f7035de1f
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
+      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "7754a1ad30ee896b265f8d14078b0513a4dba28d358eabb9d5f339886f4a1adc"
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   vector_math:
     dependency: transitive
     description:
@@ -806,18 +806,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
+      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.9"
+    version: "5.2.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   yaml:
     dependency: transitive
     description:
@@ -827,5 +827,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.2.6 <4.0.0"
+  flutter: ">=3.16.0"

--- a/APP/pubspec.yaml
+++ b/APP/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.6
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -38,17 +38,17 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  google_fonts: ^5.1.0
-  syncfusion_flutter_datepicker: ^22.1.37
+  google_fonts: ^6.1.0
+  syncfusion_flutter_datepicker: ^24.2.3
   intl: ^0.18.0
-  syncfusion_localizations: ^22.1.37
+  syncfusion_localizations: ^24.2.3
   flutter_fancy_tree_view: ^1.4.1
   http: ^1.1.0
   url_launcher: ^6.2.4
   csv: ^5.1.1
   path_provider: ^2.1.2
   universal_html: ^2.2.1
-  file_picker: ^5.2.10
+  file_picker: ^6.1.1
   flutter_dotenv: ^5.0.2
   flex_color_picker: ^3.3.1
 
@@ -63,7 +63,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^3.0.1
 
 # The following section is specific to Flutter packages.
 flutter:

--- a/BACK/app/auth/token.go
+++ b/BACK/app/auth/token.go
@@ -11,12 +11,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GenerateToken(user_id string) (string, error) {
+func GenerateToken(user_id string, stayLogged bool) (string, error) {
 
 	token_lifespan, err := strconv.Atoi(os.Getenv("TOKEN_HOUR_LIFESPAN"))
-
-	if err != nil {
-		return "", err
+	if stayLogged {
+		token_lifespan = 48 // 48h token for stay logged in
+	} else if err != nil {
+		token_lifespan = 1 // 1h as default
 	}
 
 	claims := jwt.MapClaims{}

--- a/BACK/app/handlers/docker/tenant.go
+++ b/BACK/app/handlers/docker/tenant.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -124,7 +123,7 @@ func GetContainerLogs(c *gin.Context) {
 }
 
 func AddTenant(c *gin.Context) {
-	data, e := ioutil.ReadFile("tenants.json")
+	data, e := os.ReadFile("tenants.json")
 	if e != nil {
 		panic(e.Error())
 	}
@@ -146,7 +145,7 @@ func AddTenant(c *gin.Context) {
 		// newTenant.CustomerPassword = ""
 		listTenants = append(listTenants, newTenant)
 		data, _ := json.MarshalIndent(listTenants, "", "  ")
-		_ = ioutil.WriteFile("tenants.json", data, 0755)
+		_ = os.WriteFile("tenants.json", data, 0755)
 		c.String(http.StatusOK, "Tenant created!")
 	}
 
@@ -315,7 +314,7 @@ func RemoveTenant(c *gin.Context) {
 	os.Remove(DOCKER_DIR + tenantName + ".env")
 
 	// Update local file
-	data, e := ioutil.ReadFile("tenants.json")
+	data, e := os.ReadFile("tenants.json")
 	if e != nil {
 		panic(e.Error())
 	}
@@ -327,7 +326,7 @@ func RemoveTenant(c *gin.Context) {
 		}
 	}
 	data, _ = json.MarshalIndent(listTenants, "", "  ")
-	_ = ioutil.WriteFile("tenants.json", data, 0755)
+	_ = os.WriteFile("tenants.json", data, 0755)
 	c.IndentedJSON(http.StatusOK, "all good")
 }
 
@@ -372,7 +371,7 @@ func UpdateTenant(c *gin.Context) {
 			listTenants[i] = newTenant
 			println(listTenants)
 			data, _ := json.MarshalIndent(listTenants, "", "  ")
-			_ = ioutil.WriteFile("tenants.json", data, 0755)
+			_ = os.WriteFile("tenants.json", data, 0755)
 			break
 		}
 	}

--- a/BACK/app/handlers/docker/tenant.go
+++ b/BACK/app/handlers/docker/tenant.go
@@ -251,7 +251,7 @@ func addAppAssets(newTenant models.Tenant, assestsDit string) {
 
 	// Add default logo if none already present
 	userLogo := assestsDit + "/logo.png"
-	defaultLogo := "flutter-assets/logo.png"
+	defaultLogo := "handlers/docker/flutter-assets/logo.png"
 	if _, err := os.Stat(userLogo); err == nil {
 		println("Logo already exists")
 	} else {

--- a/BACK/app/handlers/kube/auth.go
+++ b/BACK/app/handlers/kube/auth.go
@@ -50,7 +50,7 @@ func Login(c *gin.Context) {
 
 		println("Generate")
 		// Generate token
-		token, err := auth.GenerateToken(userIn.Email)
+		token, err := auth.GenerateToken(userIn.Email, userIn.StayLoggedIn)
 		if err != nil {
 			c.String(http.StatusInternalServerError, err.Error())
 			return

--- a/BACK/app/models/user.go
+++ b/BACK/app/models/user.go
@@ -1,7 +1,8 @@
 package models
 
 type User struct {
-	Email    string `json:"email" binding:"required"`
-	Password string `json:"password" binding:"required"`
-	Token    string `json:"token"`
+	Email        string `json:"email" binding:"required"`
+	Password     string `json:"password" binding:"required"`
+	Token        string `json:"token"`
+	StayLoggedIn bool   `json:"stayLoggedIn"`
 }

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -261,24 +261,14 @@ func UnsetInObj(Path, attr string, idx int) (map[string]interface{}, error) {
 		obj[attr] = arr
 	}
 
-	entity := obj["category"].(string)
 	URL, err := C.ObjectUrl(Path, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := API.Request("PUT", URL, obj, http.StatusOK)
+	_, err = API.Request("PUT", URL, obj, http.StatusOK)
 	if err != nil {
 		return nil, err
-	}
-
-	message := map[string]interface{}{
-		"type": "modify", "data": resp.Body["data"]}
-
-	//Update and inform unity
-	if models.IsPhysical(Path) && IsInObjForUnity(entity) {
-		entInt := models.EntityStrToInt(entity)
-		Ogree3D.InformOptional("UpdateObj", entInt, message)
 	}
 
 	return nil, nil

--- a/CLI/controllers/create.go
+++ b/CLI/controllers/create.go
@@ -16,12 +16,9 @@ func (controller Controller) PostObj(ent int, entity string, data map[string]any
 		return err
 	}
 
-	if models.EntityCreationMustBeInformed(ent) && IsInObjForUnity(entity) {
-		entInt := models.EntityStrToInt(entity)
+	if entInt := models.EntityStrToInt(entity); models.EntityCreationMustBeInformed(ent) &&
+		IsInObjForUnity(entity) && entInt != models.LAYER {
 		createType := "create"
-		if entInt == models.LAYER {
-			createType = "create-layer"
-		}
 		Ogree3D.InformOptional("PostObj", entInt, map[string]any{"type": createType, "data": resp.Body["data"]})
 	}
 

--- a/CLI/controllers/delete.go
+++ b/CLI/controllers/delete.go
@@ -14,22 +14,12 @@ func (controller Controller) DeleteObj(path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	objs, paths, err := controller.ParseWildcardResponse(resp, path, "DELETE "+url)
+	_, paths, err := controller.ParseWildcardResponse(resp, path, "DELETE "+url)
 	if err != nil {
 		return nil, err
 	}
-	for _, obj := range objs {
-		if models.IsPhysical(path) && IsInObjForUnity(obj["category"].(string)) {
-			controller.Ogree3D.InformOptional("DeleteObj", -1, map[string]any{"type": "delete", "data": obj["id"].(string)})
-		} else if models.IsTag(path) && IsEntityTypeForOGrEE3D(models.TAG) {
-			controller.Ogree3D.InformOptional("DeleteObj", -1, map[string]any{"type": "delete-tag", "data": obj["slug"].(string)})
-		}
-		if models.IsLayer(path) {
-			State.Hierarchy.Children["Logical"].Children["Layers"].IsCached = false
-			if IsEntityTypeForOGrEE3D(models.LAYER) {
-				controller.Ogree3D.InformOptional("DeleteObj", -1, map[string]any{"type": "delete-layer", "data": obj["slug"].(string)})
-			}
-		}
+	if models.IsLayer(path) {
+		State.Hierarchy.Children["Logical"].Children["Layers"].IsCached = false
 	}
 	if path == State.CurrPath {
 		controller.CD(TranslatePath("..", false))

--- a/CLI/controllers/delete_test.go
+++ b/CLI/controllers/delete_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeleteTagSendsDeleteTo3DWithSlug(t *testing.T) {
-	controller, mockAPI, mockOgree3D, _ := newControllerWithMocks(t)
+func TestDeleteTag(t *testing.T) {
+	controller, mockAPI, _, _ := newControllerWithMocks(t)
 
 	slug := "slug"
 	path := models.TagsPath + slug
@@ -21,11 +21,6 @@ func TestDeleteTagSendsDeleteTo3DWithSlug(t *testing.T) {
 			"color":       "aaaaaa",
 		},
 	})
-
-	mockOgree3D.On("InformOptional", "DeleteObj", -1, map[string]any{
-		"type": "delete-tag",
-		"data": slug},
-	).Return(nil)
 
 	controllers.State.ObjsForUnity = controllers.SetObjsForUnity([]string{"all"})
 

--- a/CLI/controllers/layers_test.go
+++ b/CLI/controllers/layers_test.go
@@ -680,22 +680,13 @@ func TestSelectNestedLayerSelectsAll(t *testing.T) {
 }
 
 func TestRemoveLayerRemovesAllObjectsOfTheLayer(t *testing.T) {
-	controller, mockAPI, mockOgree3D := layersSetup(t)
+	controller, mockAPI, _ := layersSetup(t)
 
 	mockGetObjectsByEntity(mockAPI, "layers", []any{})
 	mockGetObjectHierarchy(mockAPI, roomWithChildren)
 	mockDeleteObjects(mockAPI, "category=rack&id=BASIC.A.R1.*&namespace=physical.hierarchy", []any{rack1, rack2})
 
 	controllers.State.ObjsForUnity = controllers.SetObjsForUnity([]string{"all"})
-
-	mockOgree3D.On(
-		"InformOptional", "DeleteObj",
-		-1, map[string]any{"data": "BASIC.A.R1.A01", "type": "delete"},
-	).Return(nil)
-	mockOgree3D.On(
-		"InformOptional", "DeleteObj",
-		-1, map[string]any{"data": "BASIC.A.R1.B01", "type": "delete"},
-	).Return(nil)
 
 	_, err := controller.DeleteObj("/Physical/BASIC/A/R1/#racks")
 	assert.Nil(t, err)
@@ -1222,7 +1213,7 @@ func TestLsReturnsLayerCreatedAfterLastUpdate(t *testing.T) {
 }
 
 func TestLsReturnsLayerCreatedAndUpdatedAfterLastUpdate(t *testing.T) {
-	controller, mockAPI, mockOgree3D := layersSetup(t)
+	controller, mockAPI, _ := layersSetup(t)
 
 	mockGetObjectsByEntity(mockAPI, "layers", []any{})
 
@@ -1248,13 +1239,7 @@ func TestLsReturnsLayerCreatedAndUpdatedAfterLastUpdate(t *testing.T) {
 		models.LayerFilters:       map[string]any{"category": "device"},
 		models.LayerApplicability: "BASIC.A.R1",
 	})
-	mockOgree3D.On(
-		"InformOptional", "UpdateObj",
-		models.LAYER, map[string]any{"data": map[string]interface{}{
-			"layer": map[string]interface{}{
-				"applicability": "BASIC.A.R1", "filters": map[string]interface{}{"category": "device"},
-				"slug": "test"}, "old-slug": "test"}, "type": "modify-layer"},
-	).Return(nil)
+
 	err = controller.UpdateLayer("/Logical/Layers/test", models.LayerFiltersAdd, "category=device")
 	assert.Nil(t, err)
 
@@ -1272,7 +1257,7 @@ func TestLsReturnsLayerCreatedAndUpdatedAfterLastUpdate(t *testing.T) {
 }
 
 func TestLsOnLayerUpdatedAfterLastUpdateDoesUpdatedFilter(t *testing.T) {
-	controller, mockAPI, mockOgree3D := layersSetup(t)
+	controller, mockAPI, _ := layersSetup(t)
 
 	testLayer := map[string]any{
 		"slug": "test",
@@ -1298,13 +1283,7 @@ func TestLsOnLayerUpdatedAfterLastUpdateDoesUpdatedFilter(t *testing.T) {
 		models.LayerFilters:       map[string]any{"category": "device"},
 		models.LayerApplicability: "BASIC.A.R1",
 	})
-	mockOgree3D.On(
-		"InformOptional", "UpdateObj",
-		models.LAYER, map[string]any{"data": map[string]interface{}{
-			"layer": map[string]interface{}{
-				"applicability": "BASIC.A.R1", "filters": map[string]interface{}{"category": "device"},
-				"slug": "test"}, "old-slug": "test"}, "type": "modify-layer"},
-	).Return(nil)
+
 	err = controller.UpdateLayer("/Logical/Layers/test", models.LayerFiltersAdd, "category=device")
 	assert.Nil(t, err)
 

--- a/CLI/controllers/update.go
+++ b/CLI/controllers/update.go
@@ -93,31 +93,8 @@ func (controller Controller) UpdateObj(pathStr string, data map[string]any) (map
 			"param": "content",
 			"value": data["content"],
 		}
-	} else if entityType == models.TAG {
-		path, err := controller.SplitPath(pathStr)
-		if err != nil {
-			return nil, err
-		}
-
-		message["type"] = "modify-tag"
-		message["data"] = map[string]any{
-			"old-slug": path.ObjectID,
-			"tag":      resp.Body["data"],
-		}
-	} else if entityType == models.LAYER {
-		path, err := controller.SplitPath(pathStr)
-		if err != nil {
-			return nil, err
-		}
-
-		message["type"] = "modify-layer"
-		message["data"] = map[string]any{
-			"old-slug": path.ObjectID,
-			"layer":    resp.Body["data"],
-		}
 	} else {
-		message["type"] = "modify"
-		message["data"] = resp.Body["data"]
+		return resp.Body, nil
 	}
 
 	if IsEntityTypeForOGrEE3D(entityType) {

--- a/CLI/controllers/update_test.go
+++ b/CLI/controllers/update_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateTagColorSendsTagTo3DWithSameOldSlugAsSlug(t *testing.T) {
-	controller, mockAPI, mockOgree3D, _ := newControllerWithMocks(t)
+func TestUpdateTagColor(t *testing.T) {
+	controller, mockAPI, _, _ := newControllerWithMocks(t)
 
 	oldSlug := "slug"
 	path := models.TagsPath + oldSlug
@@ -31,22 +31,14 @@ func TestUpdateTagColorSendsTagTo3DWithSameOldSlugAsSlug(t *testing.T) {
 
 	mockUpdateObject(mockAPI, dataUpdate, dataUpdated)
 
-	mockOgree3D.On("InformOptional", "UpdateObj", models.TAG, map[string]any{
-		"type": "modify-tag",
-		"data": map[string]any{
-			"old-slug": oldSlug,
-			"tag":      dataUpdated,
-		},
-	}).Return(nil)
-
 	controllers.State.ObjsForUnity = controllers.SetObjsForUnity([]string{"all"})
 
 	_, err := controller.UpdateObj(path, dataUpdate)
 	assert.Nil(t, err)
 }
 
-func TestUpdateTagSlugSendsTagTo3DWithNewSlug(t *testing.T) {
-	controller, mockAPI, mockOgree3D, _ := newControllerWithMocks(t)
+func TestUpdateTagSlug(t *testing.T) {
+	controller, mockAPI, _, _ := newControllerWithMocks(t)
 
 	oldSlug := "slug"
 	newSlug := "new-slug"
@@ -69,14 +61,6 @@ func TestUpdateTagSlugSendsTagTo3DWithNewSlug(t *testing.T) {
 	}
 
 	mockUpdateObject(mockAPI, dataUpdate, dataUpdated)
-
-	mockOgree3D.On("InformOptional", "UpdateObj", models.TAG, map[string]any{
-		"type": "modify-tag",
-		"data": map[string]any{
-			"old-slug": oldSlug,
-			"tag":      dataUpdated,
-		},
-	}).Return(nil)
 
 	controllers.State.ObjsForUnity = controllers.SetObjsForUnity([]string{"all"})
 

--- a/deploy/app/launch.ps1
+++ b/deploy/app/launch.ps1
@@ -5,9 +5,9 @@ param (
  )
 
  # build front container
-cd ..\..\APP
-docker build . -t ogree-app
-$assetsDir = "${PWD}\assets\custom"
+cd ..\..
+docker build . -f APP/Dockerfile -t ogree-app
+$assetsDir = "${PWD}\APP\assets\custom"
 $file = "${assetsDir}\.env"
 (Get-Content $file) -replace '8081', $portBack | Set-Content $file
 
@@ -33,6 +33,6 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # compile and run back
-cd ..\BACK\app
+cd BACK\app
 docker run --rm -v ${PWD}:/workdir -w /workdir -e GOOS=windows golang go build -o ogree_app_backend.exe
 .\ogree_app_backend.exe -port $portBack

--- a/deploy/app/launch.sh
+++ b/deploy/app/launch.sh
@@ -15,10 +15,10 @@ do
 done
 
 # build front container
-cd ../../APP
-assetsDir="$(pwd)/assets/custom"
+cd ../..
+assetsDir="$(pwd)/APP/assets/custom"
 file="$assetsDir/.env"
-docker build . -t ogree-app
+docker build . -f APP/Dockerfile -t ogree-app
 sed -i "s/8081/$portBack/g" $file
 
 # run container
@@ -40,7 +40,7 @@ echo "Launch $containername container"
 docker run --restart always --name $containername -p $portWeb:80 -v $assetsDir:/usr/share/nginx/html/assets/assets/custom -d ogree-app:latest
 
 # compile and run back
-cd ../BACK/app
+cd BACK/app
 if $isMac; then
     echo "Compiling backend for macOS"
     docker run --rm -v $(pwd):/workdir -w /workdir -e GOOS=darwin golang go build -o ogree_app_backend

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -54,7 +54,8 @@ services:
 
   ogree_webapp:
     build:
-      context: ${CORE_DIR}/${APP_BUILD_DIR}
+      context: ${CORE_DIR}
+      dockerfile: ${APP_BUILD_DIR}/Dockerfile
     image: ogree/webapp:${IMAGE_TAG}
     profiles: ["web"]
     container_name: ${COMPOSE_PROJECT_NAME}_webapp


### PR DESCRIPTION
## Description

- [API] New /api/events endpoint to create a SSE stream from the API to the caller where a message will be sent every time an object is modified or deleted (create message only for layer). The types of message are: modify; delete; modify-tag; delete-tag; create-layer; modify-layer; delete-layer
> These messages were previously sent by the CLI.
- [APP] Login page fixes: implemented stay logged in on BACK side (normal token has 1h expiration, a stay logged in token has 48h); do not erase server input field when clicked; do not rollback server input modification when stay logged in is checked.
- [APP] Changed Dockerfile + compose to use Core as root, only way to package json schemas under API/ into APP. 
- [APP] Flutter version upgrade from 3.13.6 to 3.16.9
- [APP] Object popup fixes: fixed error deleting custom attribute, added custom attributes to modify popup. Added button to add objects when no object found.

Fixes #364 
Fixes #365

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Local test by Helder and Cedric
