### PR TITLE
Launch.ps1: avoid loop due to docker bug

### DIFF
--- a/deploy/app/launch.ps1
+++ b/deploy/app/launch.ps1
@@ -15,14 +15,20 @@ $file = "${assetsDir}\.env"
 $basename = "ogree-superadmin"
 $containername = $basename
 $index = 1
-While ($null -ne (docker ps --all --format "{{json .}}" --filter "name=$containername"))
+$result = @(docker ps --all --format "{{json .}}" --filter "name=$containername")
+While ($null -ne $result)
 {
+    if ($result -Match "failed") {
+        Write-Host "Unable to check running containers! Try default name only"
+        break
+    }
     Write-Host "Container $containername already exists"
     if ($f.IsPresent) {
         Write-Host "Stopping it if running"
         docker stop $containername
     }
     $containername = "$basename-$index"
+    $result = @(docker ps --all --format "{{json .}}" --filter "name=$containername")
     $index++
 }
 


### PR DESCRIPTION
## Description

Avoid infinite loop due to docker bug that does not let our powershell script get the output of `docker ps`.

Fixes #375

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test on Windows with docker desktop v4.27.1.
