### PR TITLE
Recursive domain update

### DIFF
--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"p3/models"
 	"p3/utils"
@@ -1208,6 +1209,10 @@ func UpdateEntity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Get query params
+	queryValues, _ := url.ParseQuery(r.URL.RawQuery)
+	isRecursiveUpdate := queryValues.Get("recursive") == "true"
+
 	// Check id and try update
 	id := mux.Vars(r)["id"]
 	if id == "" {
@@ -1215,7 +1220,7 @@ func UpdateEntity(w http.ResponseWriter, r *http.Request) {
 		u.Respond(w, u.Message("Error while extracting from path parameters"))
 		u.ErrLog("Error while extracting from path parameters", "UPDATE ENTITY", "", r)
 	} else {
-		data, modelErr = models.UpdateObject(entity, id, updateData, isPatch, user.Roles)
+		data, modelErr = models.UpdateObject(entity, id, updateData, isPatch, user.Roles, isRecursiveUpdate)
 		if modelErr != nil {
 			u.RespondWithError(w, modelErr)
 		} else {

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -470,7 +470,7 @@ func setRoomAreas(path string, values []any) (map[string]any, error) {
 	if e != nil {
 		return nil, e
 	}
-	return cmd.C.UpdateObj(path, map[string]any{"attributes": attributes})
+	return cmd.C.UpdateObj(path, map[string]any{"attributes": attributes}, false)
 }
 
 func setLabel(path string, values []any, hasSharpe bool) (map[string]any, error) {
@@ -581,7 +581,7 @@ func addRoomSeparator(path string, values []any) (map[string]any, error) {
 	newSeparator := Separator{startPos, endPos, sepType}
 	var keyExist bool
 	attr["separators"], keyExist = addToStringMap[Separator](separators, name, newSeparator)
-	obj, err = cmd.C.UpdateObj(path, map[string]any{"attributes": attr})
+	obj, err = cmd.C.UpdateObj(path, map[string]any{"attributes": attr}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -626,7 +626,7 @@ func addRoomPillar(path string, values []any) (map[string]any, error) {
 	newPillar := Pillar{centerXY, sizeXY, rotation}
 	var keyExist bool
 	attr["pillars"], keyExist = addToStringMap[Pillar](pillars, name, newPillar)
-	obj, err = cmd.C.UpdateObj(path, map[string]any{"attributes": attr})
+	obj, err = cmd.C.UpdateObj(path, map[string]any{"attributes": attr}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +658,7 @@ func deleteRoomPillarOrSeparator(path, attribute, name string) (map[string]any, 
 		return nil, fmt.Errorf("%s %s does not exist", attribute, name)
 	}
 	attributes[attribute+"s"] = stringMap
-	return cmd.C.UpdateObj(path, map[string]any{"attributes": attributes})
+	return cmd.C.UpdateObj(path, map[string]any{"attributes": attributes}, false)
 }
 
 func parseDescriptionIdx(desc string) (int, error) {
@@ -704,7 +704,7 @@ func updateDescription(path string, attr string, values []any) (map[string]any, 
 		}
 		data["description"] = curDesc
 	}
-	return cmd.C.UpdateObj(path, data)
+	return cmd.C.UpdateObj(path, data, false)
 }
 
 type updateObjNode struct {
@@ -736,7 +736,7 @@ func (n *updateObjNode) execute() (interface{}, error) {
 		var err error
 		if models.IsTag(path) {
 			if n.attr == "slug" || n.attr == "color" || n.attr == "description" {
-				_, err = cmd.C.UpdateObj(path, map[string]any{n.attr: values[0]})
+				_, err = cmd.C.UpdateObj(path, map[string]any{n.attr: values[0]}, false)
 			}
 		} else if models.IsLayer(path) {
 			err = cmd.C.UpdateLayer(path, n.attr, values[0])
@@ -766,7 +766,8 @@ func (n *updateObjNode) execute() (interface{}, error) {
 			case "pillars-":
 				_, err = deleteRoomPillarOrSeparator(path, "pillar", values[0].(string))
 			case "domain", "tags+", "tags-":
-				_, err = cmd.C.UpdateObj(path, map[string]any{n.attr: values[0]})
+				isRecursive := len(values) > 1 && values[1] == "recursive"
+				_, err = cmd.C.UpdateObj(path, map[string]any{n.attr: values[0]}, isRecursive)
 			case "tags", "separators", "pillars":
 				err = fmt.Errorf(
 					"object's %[1]s can not be updated directly, please use %[1]s+= and %[1]s-=",
@@ -804,7 +805,7 @@ func updateAttributes(path, attributeName string, values []any) (map[string]any,
 		attributes = map[string]any{attributeName: values[0]}
 	}
 
-	return cmd.C.UpdateObj(path, map[string]any{"attributes": attributes})
+	return cmd.C.UpdateObj(path, map[string]any{"attributes": attributes}, false)
 }
 
 type treeNode struct {

--- a/CLI/controllers/layer.go
+++ b/CLI/controllers/layer.go
@@ -163,11 +163,11 @@ func (controller Controller) UpdateLayer(path string, attributeName string, valu
 			return err
 		}
 
-		_, err = controller.UpdateObj(path, map[string]any{attributeName: applicability})
+		_, err = controller.UpdateObj(path, map[string]any{attributeName: applicability}, false)
 	case models.LayerFiltersAdd:
-		_, err = controller.UpdateObj(path, map[string]any{models.LayerFilters: "& (" + value.(string) + ")"})
+		_, err = controller.UpdateObj(path, map[string]any{models.LayerFilters: "& (" + value.(string) + ")"}, false)
 	default:
-		_, err = controller.UpdateObj(path, map[string]any{attributeName: value})
+		_, err = controller.UpdateObj(path, map[string]any{attributeName: value}, false)
 		if attributeName == "slug" {
 			State.Hierarchy.Children["Logical"].Children["Layers"].IsCached = false
 		}

--- a/CLI/controllers/update.go
+++ b/CLI/controllers/update.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-func (controller Controller) UpdateObj(pathStr string, data map[string]any) (map[string]any, error) {
+func (controller Controller) UpdateObj(pathStr string, data map[string]any, withRecursive bool) (map[string]any, error) {
 	attributes, hasAttributes := data["attributes"].(map[string]any)
 	if hasAttributes {
 		for key, val := range attributes {
@@ -26,6 +26,9 @@ func (controller Controller) UpdateObj(pathStr string, data map[string]any) (map
 	url, err := controller.ObjectUrl(pathStr, 0)
 	if err != nil {
 		return nil, err
+	}
+	if withRecursive {
+		url = url + "?recursive=true"
 	}
 
 	resp, err := controller.API.Request(http.MethodPatch, url, data, http.StatusOK)

--- a/CLI/controllers/update_test.go
+++ b/CLI/controllers/update_test.go
@@ -33,7 +33,7 @@ func TestUpdateTagColor(t *testing.T) {
 
 	controllers.State.ObjsForUnity = controllers.SetObjsForUnity([]string{"all"})
 
-	_, err := controller.UpdateObj(path, dataUpdate)
+	_, err := controller.UpdateObj(path, dataUpdate, false)
 	assert.Nil(t, err)
 }
 
@@ -64,6 +64,6 @@ func TestUpdateTagSlug(t *testing.T) {
 
 	controllers.State.ObjsForUnity = controllers.SetObjsForUnity([]string{"all"})
 
-	_, err := controller.UpdateObj(path, dataUpdate)
+	_, err := controller.UpdateObj(path, dataUpdate, false)
 	assert.Nil(t, err)
 }

--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -1398,7 +1398,7 @@ func newParser(buffer string) *parser {
 	}
 	p.createObjDispatch = map[string]parseCommandFunc{
 		"domain":   p.parseCreateDomain,
-		"dm":       p.parseCreateDomain,
+		"do":       p.parseCreateDomain,
 		"site":     p.parseCreateSite,
 		"si":       p.parseCreateSite,
 		"bldg":     p.parseCreateBuilding,


### PR DESCRIPTION
## Description

When trying to modify an object's domain, the API checks if the children's domain will be still coherent and it refuses if not. A recursive option is added to the CLI and API to change all children's domain to the parent's domain when changing the domain of the parent. 

Examples:
Building's domain: domain1.subdomain. Room's domain: domain1.subdomain.
Modify building's domain from domain1.subdomain to domain1 without recursive option: ✅ building set to domain1, room still domain1.subdomain.
Modify building's domain from domain1 to domain2 without recursive option: ❌ error.
Modify building's domain from domain1 to domain2 with recursive option: ✅ building and room now set to domain2.

CLI usage with recursive option:
`siteA:domain=TenantName@recursive`

Fixes #398

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test
