### PR TITLE
Add attributes to link command

### DIFF
--- a/API/controllers/entityController.go
+++ b/API/controllers/entityController.go
@@ -1806,11 +1806,8 @@ func LinkEntity(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			u.Respond(w, u.Message("Error while decoding request body: must contain parentId"))
 			return
-		} else if newName, canParse = body["name"]; !canParse && len(body) > 1 {
-			w.WriteHeader(http.StatusBadRequest)
-			u.Respond(w, u.Message("Error while decoding request body: only parentId and name accepted"))
-			return
 		}
+		newName = body["name"]
 		entityStr = "stray_object"
 	}
 
@@ -1845,9 +1842,12 @@ func LinkEntity(w http.ResponseWriter, r *http.Request) {
 	} else {
 		data["parentId"] = body["parentId"]
 		entityStr = data["category"].(string)
-		destSlot, bodyHasSlot := body["slot"]
-		if entityStr == "device" && bodyHasSlot {
-			data["slot"] = destSlot
+		delete(body, "parentId")
+		delete(body, "name")
+		for attr, value := range body {
+			println("add " + attr)
+			println(value)
+			data["attributes"].(map[string]any)[attr] = value
 		}
 	}
 	if newName != "" {

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -1515,8 +1515,9 @@ func (n *cameraWaitNode) execute() (interface{}, error) {
 type linkObjectNode struct {
 	source      node
 	destination node
-	attr        string
+	attrs       []string
 	values      []node
+	slots       []node
 }
 
 func (n *linkObjectNode) execute() (interface{}, error) {
@@ -1538,7 +1539,19 @@ func (n *linkObjectNode) execute() (interface{}, error) {
 		values = append(values, val)
 	}
 
-	return nil, cmd.LinkObject(source, dest, n.attr, values)
+	var slots []string
+	if n.slots != nil {
+		slots = []string{}
+		for _, node := range n.slots {
+			str, err := nodeToString(node, "slots")
+			slots = append(slots, str)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return nil, cmd.LinkObject(source, dest, n.attrs, values, slots)
 }
 
 type unlinkObjectNode struct {

--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -1515,7 +1515,8 @@ func (n *cameraWaitNode) execute() (interface{}, error) {
 type linkObjectNode struct {
 	source      node
 	destination node
-	slot        []node
+	attr        string
+	values      []node
 }
 
 func (n *linkObjectNode) execute() (interface{}, error) {
@@ -1528,19 +1529,16 @@ func (n *linkObjectNode) execute() (interface{}, error) {
 		return nil, err
 	}
 
-	var slot []string
-	if n.slot != nil {
-		slot = []string{}
-		for _, node := range n.slot {
-			str, err := nodeToString(node, "posU/slot")
-			slot = append(slot, str)
-			if err != nil {
-				return nil, err
-			}
+	values := []any{}
+	for _, valueNode := range n.values {
+		val, err := valueNode.execute()
+		if err != nil {
+			return nil, err
 		}
+		values = append(values, val)
 	}
 
-	return nil, cmd.LinkObject(source, dest, slot)
+	return nil, cmd.LinkObject(source, dest, n.attr, values)
 }
 
 type unlinkObjectNode struct {

--- a/CLI/completer.go
+++ b/CLI/completer.go
@@ -109,8 +109,8 @@ func UnLinkObjCompleter(line string) []string {
 	}
 
 	entities := ListEntities(splitted[1])
-	if !partTwo {
-		entities = append(entities, " @ ")
+	if !partTwo && !strings.Contains(line, "unlink") {
+		entities = append(entities, "@")
 	}
 
 	return entities

--- a/CLI/completer.go
+++ b/CLI/completer.go
@@ -102,18 +102,20 @@ func UnLinkObjCompleter(line string) []string {
 		return nil
 	}
 
-	partTwo := false
-
-	if strings.Contains(splitted[1], "@") {
-		partTwo = true
+	countAt := strings.Count(splitted[1], "@")
+	if countAt == 0 {
+		entities := ListEntities(splitted[1])
+		if !strings.Contains(line, "unlink") {
+			entities = append(entities, "@")
+		}
+		return entities
+	} else if countAt == 1 && !strings.Contains(line, "unlink") {
+		lineEntity := splitted[1]
+		lineEntity = lineEntity[strings.LastIndex(lineEntity, "@")+1:]
+		entities := ListEntities(" " + lineEntity)
+		return entities
 	}
-
-	entities := ListEntities(splitted[1])
-	if !partTwo && !strings.Contains(line, "unlink") {
-		entities = append(entities, "@")
-	}
-
-	return entities
+	return nil
 }
 
 func ListForUI(line string) []string {

--- a/CLI/completer.go
+++ b/CLI/completer.go
@@ -104,11 +104,7 @@ func UnLinkObjCompleter(line string) []string {
 
 	countAt := strings.Count(splitted[1], "@")
 	if countAt == 0 {
-		entities := ListEntities(splitted[1])
-		if !strings.Contains(line, "unlink") {
-			entities = append(entities, "@")
-		}
-		return entities
+		return ListEntities(splitted[1])
 	} else if countAt == 1 && !strings.Contains(line, "unlink") {
 		lineEntity := splitted[1]
 		lineEntity = lineEntity[strings.LastIndex(lineEntity, "@")+1:]

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -578,7 +578,7 @@ func FocusUI(path string) error {
 	return nil
 }
 
-func LinkObject(source string, destination string, attributeName string, values []any) error {
+func LinkObject(source string, destination string, attrs []string, values []any, slots []string) error {
 	sourceUrl, err := C.ObjectUrl(source, 0)
 	if err != nil {
 		return err
@@ -591,18 +591,15 @@ func LinkObject(source string, destination string, attributeName string, values 
 		return fmt.Errorf("only stray objects can be linked")
 	}
 	payload := map[string]any{"parentId": destPath.ObjectID}
-	if attributeName != "" {
-		if attributeName == "slot" {
-			slots := []string{}
-			for _, value := range values {
-				slots = append(slots, value.(string))
-			}
-			value := "[" + strings.Join(slots, ",") + "]"
-			payload["slot"] = value
-		} else {
-			payload[attributeName] = values[0]
-		}
+
+	for i, attr := range attrs {
+		payload[attr] = values[i]
 	}
+
+	if slots != nil {
+		payload["slot"] = "[" + strings.Join(slots, ",") + "]"
+	}
+
 	_, err = API.Request("PATCH", sourceUrl+"/link", payload, http.StatusOK)
 	if err != nil {
 		return err

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -578,7 +578,7 @@ func FocusUI(path string) error {
 	return nil
 }
 
-func LinkObject(source string, destination string, slot []string) error {
+func LinkObject(source string, destination string, attributeName string, values []any) error {
 	sourceUrl, err := C.ObjectUrl(source, 0)
 	if err != nil {
 		return err
@@ -591,8 +591,17 @@ func LinkObject(source string, destination string, slot []string) error {
 		return fmt.Errorf("only stray objects can be linked")
 	}
 	payload := map[string]any{"parentId": destPath.ObjectID}
-	if slot != nil {
-		payload["slot"] = "[" + strings.Join(slot, ",") + "]"
+	if attributeName != "" {
+		if attributeName == "slot" {
+			slots := []string{}
+			for _, value := range values {
+				slots = append(slots, value.(string))
+			}
+			value := "[" + strings.Join(slots, ",") + "]"
+			payload["slot"] = value
+		} else {
+			payload[attributeName] = values[0]
+		}
 	}
 	_, err = API.Request("PATCH", sourceUrl+"/link", payload, http.StatusOK)
 	if err != nil {

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -593,7 +593,7 @@ func LinkObject(source string, destination string, attrs []string, values []any,
 	payload := map[string]any{"parentId": destPath.ObjectID}
 
 	for i, attr := range attrs {
-		payload[attr] = values[i]
+		payload[attr] = Stringify(values[i])
 	}
 
 	if slots != nil {

--- a/CLI/other/man/link.txt
+++ b/CLI/other/man/link.txt
@@ -1,10 +1,11 @@
-USAGE: link [PATH/TO/STRAY-DEVICE] @ [PATH/TO/RACK/OR/DEVICE] @ Slot (Optional)    
-Moves a stray-device to a parent in the OGREE hierarchy.    
+USAGE: link [PATH/TO/STRAY-DEVICE]@[PATH/TO/PARENT]@[AttributeName=AttributeValue (Optional)]    
+Attaches a stray object to a parent in the OGREE hierarchy.    
 		
 NOTE   
-At this time it is recommended to not enclose the paths in quotes. If the parent is a device then the parent slot must be specified.        
+It is possible to also set or modify attributes of the object by adding one or more `@attributeName=attributeValue` to the command.        
 
 EXAMPLE   
 
-    link /Physical/Stray/myDevice @ /Physical/demo/buildg/room/rackA    
-    link /Physical/Stray/myDevice @ /Physical/demo/buildg/room/rackA/deviceA @ 1 
+    link /Physical/Stray@/Physical/site/bldg/room/rack
+    link /Physical/Stray@/Physical/site/bldg/room/rack@slots=[slot1,slot2]
+    link /Physical/Stray@/Physical/site/bldg/room/rack@slots=[slot1,slot2]@orientation=front

--- a/CLI/other/man/unlink.txt
+++ b/CLI/other/man/unlink.txt
@@ -1,10 +1,6 @@
-USAGE: unlink [PATH/TO/DEVICE] @ [PATH/TO/STRAY-DEVICE-PARENT] (Optional)    
-Moves a device from the OGREE hierarchy to be stray-device.    
+USAGE: unlink [PATH/TO/DEVICE]  
+Moves an object from the OGREE hierarchy to /Physical/Stray. The objet will no longer have a parent.    
 		
-NOTE   
-At this time it is recommended to not use quotes. An empty path for the destination is optional thus can be left empty         
-
 EXAMPLE   
 
-    unlink /Physical/demo/buildg/room/rackA/deviceA @ /Physical/Stray/myDevice    
-    unlink /Physical/demo/buildg/room/rackA/deviceA @ 
+    unlink /Physical/demo/buildg/room/rackA/deviceA

--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -883,10 +883,20 @@ func (p *parser) parseLink() node {
 	p.expect("@")
 	destPath := p.parsePath("destination path")
 	if p.parseExact("@") {
-		slot := p.parseStringOrVecStr("posUOrSlot")
-		return &linkObjectNode{sourcePath, destPath, slot}
+		attr := p.parseComplexWord("attribute")
+		p.skipWhiteSpaces()
+		p.expect("=")
+		p.skipWhiteSpaces()
+		values := []node{}
+		if attr == "slot" {
+			values = p.parseStringOrVecStr("slot")
+		} else {
+			value := p.parseValue()
+			values = append(values, value)
+		}
+		return &linkObjectNode{sourcePath, destPath, attr, values}
 	}
-	return &linkObjectNode{sourcePath, destPath, nil}
+	return &linkObjectNode{sourcePath, destPath, "", nil}
 }
 
 func (p *parser) parseUnlink() node {

--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -882,21 +882,24 @@ func (p *parser) parseLink() node {
 	sourcePath := p.parsePath("source path")
 	p.expect("@")
 	destPath := p.parsePath("destination path")
-	if p.parseExact("@") {
+	values := []node{}
+	attrs := []string{}
+	var slots []node
+	for p.parseExact("@") {
+		p.skipWhiteSpaces()
 		attr := p.parseComplexWord("attribute")
 		p.skipWhiteSpaces()
 		p.expect("=")
 		p.skipWhiteSpaces()
-		values := []node{}
 		if attr == "slot" {
-			values = p.parseStringOrVecStr("slot")
+			slots = p.parseStringOrVecStr("slot")
 		} else {
 			value := p.parseValue()
 			values = append(values, value)
+			attrs = append(attrs, attr)
 		}
-		return &linkObjectNode{sourcePath, destPath, attr, values}
 	}
-	return &linkObjectNode{sourcePath, destPath, "", nil}
+	return &linkObjectNode{sourcePath, destPath, attrs, values, slots}
 }
 
 func (p *parser) parseUnlink() node {

--- a/wiki/CLI-language.md
+++ b/wiki/CLI-language.md
@@ -689,7 +689,7 @@ Examples:
 [layer_path]:filters=height=[height]
 [layer_path]:filters=category=[category] & name!=[name]
 [layer_path]:filters=(name=[name] & height<[height]) | domain=[domain]
-
+```
 For the layer to filter the children whose category is device. When adding filters on different attributes, all must be fulfilled for a child to be part of the layer.
 
 Layers are not applied until their filters are defined.

--- a/wiki/CLI-language.md
+++ b/wiki/CLI-language.md
@@ -38,83 +38,7 @@
   - [Delete object](#delete-object)
   - [Focus an object](#focus-an-object)
   - [Copy object](#copy-object)
-- [Create commands](#create-commands)
-  - [Create a Tenant](#create-a-tenant)
-  - [Create a Site](#create-a-site)
-  - [Create a Building](#create-a-building)
-  - [Create a Room](#create-a-room)
-  - [Create a Rack](#create-a-rack)
-  - [Create a Device](#create-a-device)
-  - [Create a Group](#create-a-group)
-  - [Create a Corridor](#create-a-corridor)
-  - [Create a Tag](#create-a-tag)
-  - [Create a Layer](#create-a-layer)
-    - [Applicability Patterns](#applicability-patterns)
-      - [Character Classes](#character-classes)
-  - [Create a Generic Object](#create-a-generic-object)
-- [Set commands](#set-commands)
-  - [Set colors for zones of all rooms in a datacenter](#set-colors-for-zones-of-all-rooms-in-a-datacenter)
-  - [Set reserved and technical zones of a room](#set-reserved-and-technical-zones-of-a-room)
-  - [Room separators](#room-separators)
-  - [Room pillars](#room-pillars)
-  - [Modify object's attribute](#modify-objects-attribute)
-  - [Tags](#tags)
-  - [Labels](#labels)
-    - [Choose Label](#choose-label)
-    - [Modify label's font](#modify-labels-font)
-    - [Modify label's background color](#modify-labels-background-color)
-  - [Interact with objects](#interact-with-objects)
-    - [Room](#room)
-    - [Rack](#rack)
-    - [Device](#device)
-    - [Group](#group)
-- [Manipulate UI](#manipulate-ui)
-  - [Delay commands](#delay-commands)
-  - [Display infos panel](#display-infos-panel)
-  - [Display debug panel](#display-debug-panel)
-  - [Highlight object](#highlight-object)
-- [Manipulate camera](#manipulate-camera)
-  - [Move camera](#move-camera)
-  - [Translate camera](#translate-camera)
-  - [Wait between two translations](#wait-between-two-translations)
-- [Control flow](#control-flow)
-  - [Conditions](#conditions)
-  - [Loops](#loops)
-  - [Aliases](#aliases)
-- [Examples](#examples)
-- [Glossary](#glossary)
-- [Comments](#comments)
-- [Variables](#variables)
-  - [Set a variable](#set-a-variable)
-  - [Use a variable](#use-a-variable)
-- [Expressions](#expressions)
-  - [Primary expressions](#primary-expressions)
-  - [Operators](#operators)
-    - [Compute operators](#compute-operators)
-    - [Boolean operators](#boolean-operators)
-- [Print](#print)
-- [String formatting](#string-formatting)
-- [Loading commands](#loading-commands)
-  - [Load commands from a text file](#load-commands-from-a-text-file)
-  - [Commands over multiple lines](#commands-over-multiple-lines)
-  - [Load template from JSON](#load-template-from-json)
-- [Hierarchy commands](#hierarchy-commands)
-  - [Select an object](#select-an-object)
-  - [Select child / children object](#select-child--children-object)
-  - [Select parent object](#select-parent-object)
-  - [Get object/s](#get-objects)
-  - [Ls object](#ls-object)
-    - [Layers](#layers)
-      - [Room's automatic layers](#rooms-automatic-layers)
-      - [Rack's automatic layers](#racks-automatic-layers)
-      - [Device's automatic layers](#devices-automatic-layers)
-    - [Filters](#filters)
-      - [Filter by tag](#filter-by-tag)
-      - [Filter by category](#filter-by-category)
-  - [Tree](#tree)
-  - [Delete object](#delete-object)
-  - [Focus an object](#focus-an-object)
-  - [Copy object](#copy-object)
+  - [Link/Unlink object](#linkunlink-object)
 - [Create commands](#create-commands)
   - [Create a Tenant](#create-a-tenant)
   - [Create a Site](#create-a-site)
@@ -532,6 +456,28 @@ cp [source] [dest]
 ```
 
 where `[source]` is the path of the object to be copied (currently only objects in /Logical/Layers are accepted) and `[dest]` is the destination path or slug of the destination layer.
+
+## Link/Unlink object
+Unlink an object transforms the object in a stray. In other words, it moves the object from the OGrEE hierarchy (no longer has a parent) and changes its type to stray object.
+
+```
+unlink [path/to/object]
+``` 
+
+Link an object reattaches the object to the OGrEE hierarchy, giving it a parent. It is possible to also set or modify attributes of the object by adding one or more `@attributeName=attributeValue` to the command. 
+
+```
+link [path/to/stray-object]@[path/to/new/parent]
+link [path/to/stray-object]@[path/to/new/parent]@attributeName=attributeValue
+```
+
+Examples:
+
+```
+unlink /Physical/site/bldg/room/rack/device
+link /Physical/Stray@/Physical/site/bldg/room/rack
+link /Physical/Stray@/Physical/site/bldg/room/rack@slots=[slot1,slot2]@orientation=front
+```
 
 # Create commands
 


### PR DESCRIPTION
## Description

Link command now accepts multiple `@attrName=attrValue`, allowing user to set/modify attributes when linking a stray object to a new parent. 

Fixes #382 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test 
