### PR TITLE
Add DB backup restore to SuperAdmin

### DIFF
--- a/APP/lib/common/api_backend.dart
+++ b/APP/lib/common/api_backend.dart
@@ -718,6 +718,31 @@ Future<Result<dynamic, Exception>> backupTenantDB(
   }
 }
 
+Future<Result<String, Exception>> restoreTenantDB(PlatformFile backup,
+    String tenantName, String password, bool shouldDrop) async {
+  print("API upload Tenant restore");
+  try {
+    Uri url = Uri.parse('$apiUrl/api/tenants/$tenantName/restore');
+    var request = http.MultipartRequest("POST", url);
+    request.fields['password'] = password;
+    request.fields['shouldDrop'] = shouldDrop.toString();
+    request.headers.addAll(getHeader(token));
+    request.files.add(http.MultipartFile.fromBytes("file", backup.bytes!,
+        filename: backup.name));
+    var response = await request.send();
+    print(response.statusCode);
+    if (response.statusCode == 200) {
+      String msg = await response.stream.bytesToString();
+      return Success(msg);
+    } else {
+      String errorMsg = await response.stream.bytesToString();
+      return Failure(Exception(errorMsg));
+    }
+  } on Exception catch (e) {
+    return Failure(e);
+  }
+}
+
 Future<Result<void, Exception>> createBackendServer(
     Map<String, dynamic> newBackend) async {
   print("API create Back Server");

--- a/APP/lib/common/snackbar.dart
+++ b/APP/lib/common/snackbar.dart
@@ -19,14 +19,13 @@ void showSnackBar(
       SnackBar(
         behavior: SnackBarBehavior.floating,
         backgroundColor: color,
-        content: copyTextTap != ""
-            ? InkWell(
-                child: Text(message),
-                onTap: () async {
-                  await Clipboard.setData(ClipboardData(text: copyTextTap));
-                },
-              )
-            : Text(message),
+        content: InkWell(
+          child: Text(message),
+          onTap: () async {
+            await Clipboard.setData(
+                ClipboardData(text: copyTextTap == "" ? message : copyTextTap));
+          },
+        ),
         duration: duration,
         action: copyTextAction == ""
             ? null

--- a/APP/lib/l10n/app_en.arb
+++ b/APP/lib/l10n/app_en.arb
@@ -140,6 +140,9 @@
   "requestBackup": "Create database backup",
   "downloadBackup": "Download backup archive",
   "backupInfoMessage": "A backup archive file will be created in the host machine of the database container.\nIf this option is selected, this file will also be downloaded in your current machine.",
+  "restore": "Restore",
+  "dropCurrentDB": "Drop current database",
+  "restoreInfoMessage": "Everything in the current database will be erased before restoring the backup.\nIf not selected, conflicts may occur and the current DB will be favored",
 
   "tools": "Tools",
   "downloadCli": "Download latest CLI",

--- a/APP/lib/l10n/app_fr.arb
+++ b/APP/lib/l10n/app_fr.arb
@@ -172,7 +172,7 @@
   "backupInfoMessage": "Un fichier de backup sera créé dans la machine hôte de ce déploiement Docker.\nSi sélectionné, le fichier sera aussi télécharger dans votre machine.",
   "restore": "Restaurer",
   "dropCurrentDB": "Effacer la DB actuelle",
-  "restoreInfoMessage": "Toutes les données seront effacées avant de restaurer.\nSi pas selectionné, les données de la DB actuelle seront priorisées dans le cas de conflits avec le backup",
+  "restoreInfoMessage": "Toutes les données seront effacées avant de restaurer.\nSi non selectionné, les données de la DB actuelle seront priorisées dans le cas de conflits avec le backup",
 
   "tools": "Outils",
   "downloadCli": "Télécharger la CLI",

--- a/APP/lib/l10n/app_fr.arb
+++ b/APP/lib/l10n/app_fr.arb
@@ -170,6 +170,9 @@
   "requestBackup": "Créer backup de la base",
   "downloadBackup": "Télécharger archive de backup",
   "backupInfoMessage": "Un fichier de backup sera créé dans la machine hôte de ce déploiement Docker.\nSi sélectionné, le fichier sera aussi télécharger dans votre machine.",
+  "restore": "Restaurer",
+  "dropCurrentDB": "Effacer la DB actuelle",
+  "restoreInfoMessage": "Toutes les données seront effacées avant de restaurer.\nSi pas selectionné, les données de la DB actuelle seront priorisées dans le cas de conflits avec le backup",
 
   "tools": "Outils",
   "downloadCli": "Télécharger la CLI",

--- a/APP/lib/widgets/common/delete_dialog_popup.dart
+++ b/APP/lib/widgets/common/delete_dialog_popup.dart
@@ -69,7 +69,9 @@ class _DeleteDialogState extends State<DeleteDialog> {
                             case Success():
                               break;
                             case Failure(exception: final exception):
-                              showSnackBar(messenger, "Error: $exception");
+                              showSnackBar(messenger, "Error: $exception",
+                                  isError: true,
+                                  duration: const Duration(seconds: 30));
                               setState(() => _isLoading = false);
                               return;
                           }

--- a/APP/lib/widgets/tenants/popups/backup_popup.dart
+++ b/APP/lib/widgets/tenants/popups/backup_popup.dart
@@ -172,9 +172,10 @@ class _BackupPopupState extends State<BackupPopup> {
               var path = (await getApplicationDocumentsDirectory()).path;
               var fileName = '$path/$filename';
               var file = File(fileName);
-              file.writeAsBytes(value, flush: true).then((value) => showSnackBar(
-                  messenger,
-                  "${AppLocalizations.of(context)!.fileSavedTo} $fileName"));
+              file.writeAsBytes(value, flush: true).then((value) =>
+                  showSnackBar(messenger,
+                      "${AppLocalizations.of(context)!.fileSavedTo} $fileName",
+                      copyTextTap: fileName));
             }
           } else {
             showSnackBar(messenger, value, isSuccess: true);

--- a/APP/lib/widgets/tenants/popups/backup_popup.dart
+++ b/APP/lib/widgets/tenants/popups/backup_popup.dart
@@ -1,5 +1,6 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:intl/intl.dart';
 import 'package:ogree_app/common/api_backend.dart';
 import 'package:ogree_app/common/definitions.dart';
@@ -21,12 +22,22 @@ class BackupPopup extends StatefulWidget {
   State<BackupPopup> createState() => _BackupPopupState();
 }
 
-class _BackupPopupState extends State<BackupPopup> {
+class _BackupPopupState extends State<BackupPopup>
+    with TickerProviderStateMixin {
   final _formKey = GlobalKey<FormState>();
   String? _tenantPassword;
-  bool _shouldDownload = false;
+  bool _isChecked = false;
   bool _isSmallDisplay = false;
   bool _isLoading = false;
+  late TabController _tabController;
+  PlatformFile? _loadedFile;
+  String? _loadFileResult;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -35,111 +46,58 @@ class _BackupPopupState extends State<BackupPopup> {
     return Center(
       child: Container(
         width: 500,
-        constraints: const BoxConstraints(maxHeight: 230),
+        constraints: const BoxConstraints(maxHeight: 260),
         margin: const EdgeInsets.symmetric(horizontal: 20),
         decoration: PopupDecoration,
         child: Padding(
           padding: EdgeInsets.fromLTRB(
-              _isSmallDisplay ? 30 : 40, 20, _isSmallDisplay ? 30 : 40, 15),
+              _isSmallDisplay ? 20 : 40, 8, _isSmallDisplay ? 20 : 40, 15),
           child: Form(
             key: _formKey,
             child: ScaffoldMessenger(
                 child: Builder(
                     builder: (context) => Scaffold(
                           backgroundColor: Colors.white,
-                          body: ListView(
-                            padding: EdgeInsets.zero,
+                          body: Column(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
                             children: [
-                              Center(
-                                  child: Text(
-                                localeMsg.requestBackup,
-                                style:
-                                    Theme.of(context).textTheme.headlineMedium,
-                              )),
-                              const SizedBox(height: 20),
-                              CustomFormField(
-                                  save: (newValue) =>
-                                      _tenantPassword = newValue,
-                                  label: localeMsg.tenantPassword,
-                                  icon: Icons.lock),
-                              const SizedBox(height: 10),
-                              Row(
-                                children: [
-                                  const SizedBox(width: 15),
-                                  SizedBox(
-                                    height: 24,
-                                    width: 24,
-                                    child: Checkbox(
-                                      activeColor: Colors.blue.shade600,
-                                      value: _shouldDownload,
-                                      onChanged: (bool? value) => setState(
-                                          () => _shouldDownload = value!),
-                                    ),
+                              TabBar(
+                                tabAlignment: TabAlignment.center,
+                                controller: _tabController,
+                                labelStyle: TextStyle(
+                                    fontSize: 15,
+                                    fontFamily: GoogleFonts.inter().fontFamily),
+                                unselectedLabelStyle: TextStyle(
+                                    fontSize: 15,
+                                    fontFamily: GoogleFonts.inter().fontFamily),
+                                isScrollable: true,
+                                indicatorSize: TabBarIndicatorSize.label,
+                                tabs: [
+                                  const Tab(
+                                    text: "Backup DB",
                                   ),
-                                  const SizedBox(width: 8),
-                                  Text(
-                                    localeMsg.downloadBackup,
-                                    style: const TextStyle(
-                                      fontSize: 14,
-                                      color: Colors.black,
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Tooltip(
-                                    message: localeMsg.backupInfoMessage,
-                                    verticalOffset: 13,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.blueAccent,
-                                      borderRadius:
-                                          BorderRadius.all(Radius.circular(12)),
-                                    ),
-                                    textStyle: const TextStyle(
-                                      fontSize: 13,
-                                      color: Colors.white,
-                                      height: 1.5,
-                                    ),
-                                    padding: const EdgeInsets.all(16),
-                                    child: const Icon(
-                                        Icons.info_outline_rounded,
-                                        color: Colors.blueAccent,
-                                        size: 18),
+                                  Tab(
+                                    text: "${localeMsg.restore} DB",
                                   ),
                                 ],
                               ),
-                              const SizedBox(height: 20),
-                              Row(
-                                mainAxisAlignment: MainAxisAlignment.end,
-                                children: [
-                                  TextButton.icon(
-                                    style: OutlinedButton.styleFrom(
-                                        foregroundColor: Colors.blue.shade900),
-                                    onPressed: () => Navigator.pop(context),
-                                    label: Text(localeMsg.cancel),
-                                    icon: const Icon(
-                                      Icons.cancel_outlined,
-                                      size: 16,
-                                    ),
+                              SizedBox(
+                                height: 189,
+                                child: Padding(
+                                  padding: const EdgeInsets.only(top: 16.0),
+                                  child: TabBarView(
+                                    physics:
+                                        const NeverScrollableScrollPhysics(),
+                                    controller: _tabController,
+                                    children: [
+                                      getBackupView(localeMsg),
+                                      getRestoreView(localeMsg),
+                                    ],
                                   ),
-                                  const SizedBox(width: 15),
-                                  ElevatedButton.icon(
-                                      onPressed: requestBackup,
-                                      label: Text(localeMsg.create),
-                                      icon: _isLoading
-                                          ? Container(
-                                              width: 24,
-                                              height: 24,
-                                              padding:
-                                                  const EdgeInsets.all(2.0),
-                                              child:
-                                                  const CircularProgressIndicator(
-                                                color: Colors.white,
-                                                strokeWidth: 3,
-                                              ),
-                                            )
-                                          : const Icon(Icons.check_circle,
-                                              size: 16))
-                                ],
-                              )
+                                ),
+                              ),
+                              // const SizedBox(height: 20),
                             ],
                           ),
                         ))),
@@ -149,15 +107,219 @@ class _BackupPopupState extends State<BackupPopup> {
     );
   }
 
+  getBackupView(AppLocalizations localeMsg) {
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: [
+        const SizedBox(height: 10),
+        CustomFormField(
+            save: (newValue) => _tenantPassword = newValue,
+            label: localeMsg.tenantPassword,
+            icon: Icons.lock),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            const SizedBox(width: 15),
+            SizedBox(
+              height: 24,
+              width: 24,
+              child: Checkbox(
+                activeColor: Colors.blue.shade600,
+                value: _isChecked,
+                onChanged: (bool? value) => setState(() => _isChecked = value!),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              localeMsg.downloadBackup,
+              style: const TextStyle(
+                fontSize: 14,
+                color: Colors.black,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Tooltip(
+              message: localeMsg.backupInfoMessage,
+              verticalOffset: 13,
+              decoration: const BoxDecoration(
+                color: Colors.blueAccent,
+                borderRadius: BorderRadius.all(Radius.circular(12)),
+              ),
+              textStyle: const TextStyle(
+                fontSize: 13,
+                color: Colors.white,
+                height: 1.5,
+              ),
+              padding: const EdgeInsets.all(16),
+              child: const Icon(Icons.info_outline_rounded,
+                  color: Colors.blueAccent, size: 18),
+            ),
+          ],
+        ),
+        const SizedBox(height: 30),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton.icon(
+              style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.blue.shade900),
+              onPressed: () => Navigator.pop(context),
+              label: Text(localeMsg.cancel),
+              icon: const Icon(
+                Icons.cancel_outlined,
+                size: 16,
+              ),
+            ),
+            const SizedBox(width: 15),
+            ElevatedButton.icon(
+                onPressed: requestBackup,
+                label: const Text("Backup"),
+                icon: _isLoading
+                    ? Container(
+                        width: 24,
+                        height: 24,
+                        padding: const EdgeInsets.all(2.0),
+                        child: const CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 3,
+                        ),
+                      )
+                    : const Icon(Icons.history, size: 16))
+          ],
+        )
+      ],
+    );
+  }
+
+  getRestoreView(AppLocalizations localeMsg) {
+    return ListView(
+      padding: EdgeInsets.zero,
+      children: [
+        CustomFormField(
+            save: (newValue) => _tenantPassword = newValue,
+            label: localeMsg.tenantPassword,
+            icon: Icons.lock),
+        const SizedBox(height: 2),
+        Row(
+          children: [
+            const SizedBox(width: 15),
+            SizedBox(
+              height: 24,
+              width: 24,
+              child: Checkbox(
+                activeColor: Colors.blue.shade600,
+                value: _isChecked,
+                onChanged: (bool? value) => setState(() => _isChecked = value!),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              localeMsg.dropCurrentDB,
+              style: const TextStyle(
+                fontSize: 14,
+                color: Colors.black,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Tooltip(
+              message: localeMsg.restoreInfoMessage,
+              verticalOffset: 13,
+              decoration: const BoxDecoration(
+                color: Colors.blueAccent,
+                borderRadius: BorderRadius.all(Radius.circular(12)),
+              ),
+              textStyle: const TextStyle(
+                fontSize: 13,
+                color: Colors.white,
+                height: 1.5,
+              ),
+              padding: const EdgeInsets.all(16),
+              child: const Icon(Icons.info_outline_rounded,
+                  color: Colors.blueAccent, size: 18),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        _loadFileResult == null
+            ? Align(
+                alignment: Alignment.bottomRight,
+                child: ElevatedButton.icon(
+                    onPressed: () async {
+                      FilePickerResult? result =
+                          await FilePicker.platform.pickFiles(withData: true);
+                      if (result != null) {
+                        setState(() {
+                          _loadedFile = result.files.single;
+                        });
+                      }
+                    },
+                    icon: Icon(_loadedFile != null
+                        ? Icons.check_circle
+                        : Icons.download),
+                    label: _loadedFile != null
+                        ? Text(_loadedFile!.name)
+                        : Text("${localeMsg.select} backup")),
+              )
+            : Container(),
+        _loadFileResult != null
+            ? Container(
+                color: Colors.black,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    'Result:\n$_loadFileResult',
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+              )
+            : Container(),
+        const SizedBox(height: 10),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton.icon(
+              style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.blue.shade900),
+              onPressed: () => Navigator.pop(context),
+              label: Text(localeMsg.cancel),
+              icon: const Icon(
+                Icons.cancel_outlined,
+                size: 16,
+              ),
+            ),
+            const SizedBox(width: 15),
+            ElevatedButton.icon(
+                onPressed: requestRestore,
+                label: Text(localeMsg.restore),
+                icon: _isLoading
+                    ? Container(
+                        width: 24,
+                        height: 24,
+                        padding: const EdgeInsets.all(2.0),
+                        child: const CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 3,
+                        ),
+                      )
+                    : const Icon(Icons.history, size: 16))
+          ],
+        )
+      ],
+    );
+  }
+
   requestBackup() async {
     if (_formKey.currentState!.validate()) {
       _formKey.currentState!.save();
+      setState(() {
+        _isLoading = true;
+      });
       final messenger = ScaffoldMessenger.of(context);
-      final result = await backupTenantDB(
-          widget.tenantName, _tenantPassword!, _shouldDownload);
+      final result =
+          await backupTenantDB(widget.tenantName, _tenantPassword!, _isChecked);
       switch (result) {
         case Success(value: final value):
-          if (_shouldDownload) {
+          if (_isChecked) {
             String filename =
                 "${widget.tenantName}_db_${DateFormat('yyyy-MM-ddTHHmmss').format(DateTime.now())}.archive";
             if (kIsWeb) {
@@ -180,6 +342,38 @@ class _BackupPopupState extends State<BackupPopup> {
           } else {
             showSnackBar(messenger, value, isSuccess: true);
           }
+        case Failure(exception: final exception):
+          showSnackBar(messenger, exception.toString(), isError: true);
+      }
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  requestRestore() async {
+    final localeMsg = AppLocalizations.of(context)!;
+    if (_loadedFile == null) {
+      showSnackBar(ScaffoldMessenger.of(context), localeMsg.mustSelectFile);
+      return;
+    }
+    if (_formKey.currentState!.validate()) {
+      _formKey.currentState!.save();
+      setState(() {
+        _isLoading = true;
+        _loadFileResult = null;
+      });
+      final messenger = ScaffoldMessenger.of(context);
+      final result = await restoreTenantDB(
+          _loadedFile!, widget.tenantName, _tenantPassword!, _isChecked);
+      switch (result) {
+        case Success(value: final value):
+          showSnackBar(messenger,
+              "Backup restored: ${value.substring(value.lastIndexOf("+0000") + 5).trim()}");
+          setState(() {
+            _loadFileResult = value;
+            _isLoading = false;
+          });
         case Failure(exception: final exception):
           setState(() {
             _isLoading = false;

--- a/APP/lib/widgets/tenants/popups/backup_popup.dart
+++ b/APP/lib/widgets/tenants/popups/backup_popup.dart
@@ -369,7 +369,8 @@ class _BackupPopupState extends State<BackupPopup>
       switch (result) {
         case Success(value: final value):
           showSnackBar(messenger,
-              "Backup restored: ${value.substring(value.lastIndexOf("+0000") + 5).trim()}");
+              "Backup restored: ${value.substring(value.lastIndexOf("+0000") + 5).trim()}",
+              duration: const Duration(seconds: 10));
           setState(() {
             _loadFileResult = value;
             _isLoading = false;

--- a/APP/pubspec.lock
+++ b/APP/pubspec.lock
@@ -405,30 +405,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -449,26 +425,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -497,10 +473,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_provider:
     dependency: "direct main"
     description:
@@ -802,14 +778,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
   watcher:
     dependency: transitive
     description:

--- a/BACK/app/handlers/docker/tenant.go
+++ b/BACK/app/handlers/docker/tenant.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 )
 
 func GetTenants(c *gin.Context) {
@@ -432,6 +433,48 @@ func BackupTenantDB(c *gin.Context) {
 	} else {
 		c.String(http.StatusOK, "Backup file created as "+outfile.Name()+" at "+dir)
 	}
+}
+
+func RestoreTenantDB(c *gin.Context) {
+	tenantName := strings.ToLower(c.Param("name"))
+
+	// Bind received data
+	var updateRequest models.Restore
+	if err := c.ShouldBindWith(&updateRequest, binding.FormMultipart); err != nil {
+		_ = c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	// Load dump and save it locally
+	formFile := updateRequest.File
+	err := c.SaveUploadedFile(formFile, DOCKER_DIR+"/dump.archive")
+	if err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+	}
+
+	// Restore
+	println("Docker restore backup tenant")
+	restoreCmd := "mongorestore --username ogree" + tenantName + "Admin --password " + updateRequest.DBPassword + " -d ogree" + tenantName + " --archive"
+	if updateRequest.IsDrop == "true" {
+		restoreCmd = restoreCmd + " --drop"
+	}
+	args := []string{"exec", "-i", tenantName + "_db", "sh", "-c", restoreCmd}
+	cmd := exec.Command("docker", args...)
+	cmd.Dir = DOCKER_DIR
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdin, _ = os.Open(DOCKER_DIR + "/dump.archive")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		fmt.Println(fmt.Sprint(err) + ": " + stderr.String())
+		c.String(http.StatusInternalServerError, stderr.String())
+	} else {
+		// even if ok, the output is always in stderr
+		fmt.Println("ok: " + stderr.String())
+		c.String(http.StatusOK, stderr.String())
+	}
+	println("Finished with docker")
 }
 
 func StopStartTentant(c *gin.Context) {

--- a/BACK/app/models/tenants.go
+++ b/BACK/app/models/tenants.go
@@ -1,5 +1,7 @@
 package models
 
+import "mime/multipart"
+
 type Tenant struct {
 	Name             string `json:"name" binding:"required"`
 	CustomerPassword string `json:"customerPassword"`
@@ -58,4 +60,10 @@ type APPFile struct {
 type Backup struct {
 	DBPassword string `json:"password" binding:"required"`
 	IsDownload bool   `json:"shouldDownload"`
+}
+
+type Restore struct {
+	File       *multipart.FileHeader `form:"file" binding:"required"`
+	DBPassword string                `form:"password" binding:"required"`
+	IsDrop     string                `form:"shouldDrop"`
 }

--- a/BACK/app/services/router.go
+++ b/BACK/app/services/router.go
@@ -68,6 +68,7 @@ func InitRouter(isKube bool) *gin.Engine {
 		protected.POST("/tenants/:name/logo", docker.AddTenantLogo)
 		protected.PUT("/tenants/:name", docker.UpdateTenant)
 		protected.POST("/tenants/:name/backup", docker.BackupTenantDB)
+		protected.POST("/tenants/:name/restore", docker.RestoreTenantDB)
 		protected.POST("/tenants/:name/stop", docker.StopStartTentant)
 		protected.POST("/tenants/:name/start", docker.StopStartTentant)
 		protected.GET("/containers/:name", docker.GetContainerLogs)


### PR DESCRIPTION
## Description

Restore a mongo DB dump to a tenant. As a plus, an error popup for deleting a tenant has longer duration and all the error popups are now "tap to copy".

Fixes #402

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test 
