### PR TITLE
Accept variables for device's slot vector

### DIFF
--- a/CLI/parser_test.go
+++ b/CLI/parser_test.go
@@ -198,7 +198,7 @@ func TestParseExprArrayRef(t *testing.T) {
 func TestParseRawText(t *testing.T) {
 	defer recoverFunc(t)
 	p := newParser("${a}a")
-	expr := p.parseText(p.parseUnquotedStringToken, false)
+	expr := p.parseText(p.parseUnquotedStringToken, false, false)
 	expected := &formatStringNode{&valueNode{"%va"}, []node{&symbolReferenceNode{"a"}}}
 	if !reflect.DeepEqual(expr, expected) {
 		t.Errorf("unexpected expression : \n%s", spew.Sdump(expr))


### PR DESCRIPTION
## Description

If a var x is created with a value, the following command will now be accepted: 
`+device:banana@[blade0$x]@ibm-example`

Fixes #404

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test 
