### PR TITLE
Add .. to slots range for devices

### DIFF
--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"cli/config"
+	"cli/controllers"
 	cmd "cli/controllers"
 	"cli/models"
 	"cli/utils"
@@ -795,6 +796,10 @@ func updateAttributes(path, attributeName string, values []any) (map[string]any,
 		slots := []string{}
 		for _, value := range values {
 			slots = append(slots, value.(string))
+		}
+		var err error
+		if slots, err = controllers.ExpandSlotVector(slots); err != nil {
+			return nil, err
 		}
 		value := "[" + strings.Join(slots, ",") + "]"
 		attributes = map[string]any{attributeName: value}

--- a/CLI/controllers/commandController.go
+++ b/CLI/controllers/commandController.go
@@ -597,6 +597,9 @@ func LinkObject(source string, destination string, attrs []string, values []any,
 	}
 
 	if slots != nil {
+		if slots, err = ExpandSlotVector(slots); err != nil {
+			return err
+		}
 		payload["slot"] = "[" + strings.Join(slots, ",") + "]"
 	}
 

--- a/CLI/controllers/create.go
+++ b/CLI/controllers/create.go
@@ -280,7 +280,11 @@ func (controller Controller) CreateObject(path string, ent int, data map[string]
 			if _, err := strconv.Atoi(x[0]); len(x) == 1 && err == nil {
 				attr["posU"] = x[0]
 			} else {
-				attr["slot"] = x
+				if slots, err := ExpandSlotVector(x); err != nil {
+					return err
+				} else {
+					attr["slot"] = slots
+				}
 			}
 
 		}

--- a/CLI/controllers/sendSchemaController.go
+++ b/CLI/controllers/sendSchemaController.go
@@ -218,3 +218,37 @@ func Stringify(x interface{}) string {
 	}
 	return ""
 }
+
+// ExpandSlotVector: allow usage of .. on slot vector, converting as bellow:
+// [slot01..slot03] => [slot01,slot02,slot03]
+func ExpandSlotVector(slotVector []string) ([]string, error) {
+	slots := []string{}
+	for _, slot := range slotVector {
+		if strings.Contains(slot, "..") {
+			if len(slotVector) != 1 {
+				return nil, fmt.Errorf("Invalid device syntax: .. can only be used in a single element vector")
+			}
+			parts := strings.Split(slot, "..")
+			if len(parts) != 2 ||
+				(parts[0][:len(parts[0])-1] != parts[1][:len(parts[1])-1]) {
+				l.GetWarningLogger().Println("Invalid device syntax encountered")
+				return nil, fmt.Errorf("Invalid device syntax: incorrect use of .. for slot")
+			} else {
+				start, errS := strconv.Atoi(string(parts[0][len(parts[0])-1]))
+				end, errE := strconv.Atoi(string(parts[1][len(parts[1])-1]))
+				if errS != nil || errE != nil {
+					l.GetWarningLogger().Println("Invalid device syntax encountered")
+					return nil, fmt.Errorf("Invalid device syntax: incorrect use of .. for slot")
+				} else {
+					prefix := parts[0][:len(parts[0])-1]
+					for i := start; i <= end; i++ {
+						slots = append(slots, prefix+strconv.Itoa(i))
+					}
+				}
+			}
+		} else {
+			slots = append(slots, slot)
+		}
+	}
+	return slots, nil
+}

--- a/wiki/CLI-language.md
+++ b/wiki/CLI-language.md
@@ -561,7 +561,7 @@ Rack must be child of a room.
 A chassis is a *parent* device racked at a defined U position.  
 *`[posU]` is the position in U in a rack  
 `[sizeU]` is the height in U in a rack  
-`[slot]` is a square brackets list [] with the names of slots in which you want to place the device separated by a comma. Example: [slot1, slot2, slot3]. If no template is given, only one slot can be provided in the list.  
+`[slot]` is a square brackets list [] with the names of slots in which you want to place the device separated by a comma. Example: [slot1, slot2, slot3]. A shorter version with `..` can be used for a single range of slots: [slot1..slot3]. If no template is given, only one slot can be provided in the list.  
 `[template]` is the name of the device template  
 `[invertOffset]` is a boolean that tells the 3D client to invert the default offset for positioning the device in its slot (false by default, if not provided)  
 `[side]` is from which side you can see the device if not "fullsize". This value is for overriding the one defined in the template. It can be front | rear | frontflipped | rearflipped*  


### PR DESCRIPTION
## Description

`+device:dev10@[blade01..blade05]@ibm-example`
The above is now the same as:
`+device:dev10@[blade01,blade02,blade03,blade04,blade05]@ibm-example`

Fixes #413

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test
