### PR TITLE
[API] Add get schemas endpoint [APP] Use endpoint insted of assets

### DIFF
--- a/API/controllers/image.go
+++ b/API/controllers/image.go
@@ -27,7 +27,7 @@ func imageIDToUrl(entity int, object map[string]any) map[string]any {
 	return object
 }
 
-// swagger:operation GET /api/image/{id} Objects GetImage
+// swagger:operation GET /api/images/{id} Objects GetImage
 // Gets an image by its id.
 // Returns a HTTP response with the binary of the image.
 // The format of the image will correspond to the content type of the response.

--- a/API/controllers/schema.go
+++ b/API/controllers/schema.go
@@ -1,0 +1,51 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+	"p3/models"
+	u "p3/utils"
+
+	"github.com/gorilla/mux"
+)
+
+// swagger:operation GET /api/schemas/{id} Objects GetSchemaJSON
+// Gets a JSON schema by its file name (id).
+// Returns a HTTP response with the content of the schema in the body (json format).
+// JSON schemas define the format of each entity of the API.
+// ---
+// security:
+// - bearer: []
+// produces:
+// - application/json
+// parameters:
+// - name: id
+//   in: path
+//   description: Name of the JSON schema
+//   required: true
+//   type: string
+// responses:
+//     '200':
+//         description: Found. A response body will be returned with the schema content.
+//     '404':
+//         description: Not Found. An error message will be returned.
+
+func GetSchemaJSON(w http.ResponseWriter, r *http.Request) {
+	fmt.Println("******************************************************")
+	fmt.Println("FUNCTION CALL: 	 GetSchemaJSON ")
+	fmt.Println("******************************************************")
+	DispRequestMetaData(r)
+
+	file, err := models.GetSchemaFile(mux.Vars(r)["id"])
+	if err != nil {
+		u.ErrLog("Error while getting schema",
+			"GET GetSchemaJSON", err.Message, r)
+		u.RespondWithError(w, err)
+	} else if r.Method == "OPTIONS" {
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Allow", "GET, OPTIONS")
+	} else {
+		w.Header().Add("Content-Type", "application/json")
+		w.Write(file)
+	}
+}

--- a/API/models/schema.go
+++ b/API/models/schema.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	u "p3/utils"
+	"strings"
+)
+
+// Returns the json schema content of the requested id (schema name)
+func GetSchemaFile(id string) ([]byte, *u.Error) {
+	var schemaPath = "schemas/"
+
+	if strings.HasSuffix(id, ".json") {
+		if id == "types.json" || id == "base.json" {
+			schemaPath = schemaPath + "refs/"
+		}
+		file, err := embeddfs.ReadFile(schemaPath + id)
+		if err == nil {
+			return file, nil
+		} else {
+			// not found
+			println(err.Error())
+			return nil, &u.Error{Type: u.ErrNotFound, Message: "Requested file not found"}
+		}
+	} else {
+		//only json accepted
+		return nil, &u.Error{Type: u.ErrInvalidValue, Message: "Only files with .json extension"}
+	}
+}

--- a/API/router/router.go
+++ b/API/router/router.go
@@ -75,6 +75,10 @@ func Router(jwt func(next http.Handler) http.Handler) *mux.Router {
 	router.HandleFunc(controllers.GetImagePath+"{id}",
 		controllers.GetImage).Methods("GET", "HEAD", "OPTIONS")
 
+	// JSON schemas
+	router.HandleFunc("/api/schemas/{id}",
+		controllers.GetSchemaJSON).Methods("GET", "HEAD", "OPTIONS")
+
 	// For obtaining the complete hierarchy (tree)
 	router.HandleFunc("/api/hierarchy",
 		controllers.GetCompleteHierarchy).Methods("GET", "OPTIONS", "HEAD")

--- a/APP/lib/common/api_backend.dart
+++ b/APP/lib/common/api_backend.dart
@@ -947,3 +947,20 @@ Future<Result<void, Exception>> importNetboxDump() async {
     return Failure(e);
   }
 }
+
+Future<Result<Map<String, dynamic>, Exception>> fetchSchema(String id) async {
+  print("API fetch Schema");
+  try {
+    Uri url = Uri.parse('$apiUrl/api/schemas/$id');
+    final response = await http.get(url, headers: getHeader(token));
+    if (response.statusCode == 200) {
+      Map<String, dynamic> data = json.decode(response.body);
+      return Success(data);
+    } else {
+      final Map<String, dynamic> data = json.decode(response.body);
+      return Failure(Exception(data["message"].toString()));
+    }
+  } on Exception catch (e) {
+    return Failure(e);
+  }
+}

--- a/APP/pubspec.yaml
+++ b/APP/pubspec.yaml
@@ -82,5 +82,3 @@ flutter:
     - assets/server_background.png
     - lib/l10n/app_fr.arb
     - assets/custom/.env
-    - ../API/models/schemas/
-    - ../API/models/schemas/refs/

--- a/APP/windows/flutter/CMakeLists.txt
+++ b/APP/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
## Description

Bundled assets from a relative path were not working correctly for all platforms, so the APP will now request the JSON schemas from the API instead.

Fixes #432

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Local test on Windows and Linux
