### PR TITLE
Change delete object attribute syntax

### DIFF
--- a/CLI/ast.go
+++ b/CLI/ast.go
@@ -358,6 +358,19 @@ func (n *deleteSelectionNode) execute() (interface{}, error) {
 	return nil, nil
 }
 
+type deleteAttrNode struct {
+	path node
+	attr string
+}
+
+func (n *deleteAttrNode) execute() (interface{}, error) {
+	path, err := nodeToString(n.path, "path")
+	if err != nil {
+		return nil, err
+	}
+	return nil, cmd.UnsetAttribute(path, n.attr)
+}
+
 type isEntityDrawableNode struct {
 	path node
 }

--- a/CLI/other/man/minus.txt
+++ b/CLI/other/man/minus.txt
@@ -1,14 +1,14 @@
-USAGE: - [PATH]   
-Delete an object at current path. A selection of objects can optionally be deleted if 'selection' was provided as the PATH parameter. If the PATH is not specified then the current path will be used  
+USAGE: - [PATH] [:ATTRIBUTE](optional)
+Delete an object or the attribute of an object at path.
+If the PATH is not specified then the current path will be used.
+If :ATTRIBUTE is provided, that attribute of the given PATH object will be removed.
 
 NOTE:
-
-    You must include a space between the '-' operator and its argument (path to object)
-
-    You may also delete a selection of objects by issuing the 'selection' keyword
+    You may also delete a selection of objects by issuing the 'selection' keyword (no :ATTRIBUTE allowed). 
 
 EXAMPLE:
 
-    - DEMO/ALPHA
-    - selection
-    - .
+    -DEMO/SITE
+    -selection
+    -.
+    -DEMO/SITE:attributeToRemove

--- a/CLI/other/man/unset.txt
+++ b/CLI/other/man/unset.txt
@@ -1,12 +1,6 @@
 USAGE:  unset [OPTIONS] [VAR/FUNC NAME]     
-Deletes function or variable or attribute of an object   
+Deletes function or variable
 
-There is an alternative usage for deleting an attribute of an object or an element in an attribute:   
-```
-unset [PATH/TO/OBJECT]:[ATTRIBUTE]
-unset [PATH/TO/OBJECT]:[ATTRIBUTE][INDEX]
-```   
-Note that the attribute must be in quotes!
 OPTIONS
 
 -v    Deletes variable
@@ -16,6 +10,4 @@ EXAMPLE
 
     unset -v myVariable
     unset -f myFunc
-    unset path/to/room:attribute1
-    unset path/to/object:description[3]
     

--- a/CLI/parser.go
+++ b/CLI/parser.go
@@ -808,14 +808,8 @@ func (p *parser) parseUnset() node {
 	defer un(trace(p, "unset"))
 	args := p.parseArgs([]string{"f", "v"}, []string{}, "unset")
 	if len(args) == 0 {
-		path := p.parsePath("")
-		p.expect(":")
-		attr := p.parseComplexWord("attribute")
-		if p.commandEnd() {
-			return &unsetAttrNode{path, attr, nil}
-		}
-		index := p.parseIndexing()
-		return &unsetAttrNode{path, attr, index}
+		p.error("an argument is mandatory: -f or -v")
+		return nil
 	}
 	if funcName, ok := args["f"]; ok {
 		return &unsetFuncNode{funcName}
@@ -823,7 +817,8 @@ func (p *parser) parseUnset() node {
 	if varName, ok := args["v"]; ok {
 		return &unsetVarNode{varName}
 	}
-	panic("unexpected argument while unset command")
+	p.error("unexpected argument while unset command")
+	return nil
 }
 
 func (p *parser) parseEnv() node {
@@ -843,8 +838,12 @@ func (p *parser) parseDelete() node {
 		p.error("path expected")
 	}
 	path := p.parsePath("")
-
-	return &deleteObjNode{path}
+	if p.parseExact(":") {
+		attr := p.parseComplexWord("attribute")
+		return &deleteAttrNode{path, attr}
+	} else {
+		return &deleteObjNode{path}
+	}
 }
 
 func (p *parser) parseEqual() node {


### PR DESCRIPTION
## Description

The unset command option to delete object attribute is replaced by a new syntax:
```
-[name]:[attribute]
-siteE:myattr
 ```

Fixes #436

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Local test
